### PR TITLE
Every 1000-2000 Calls Yields a Malformed Response

### DIFF
--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -240,6 +240,7 @@ function requestCallback(callback) {
       var err = body.meta ? body.meta.msg : body.error;
       return callback(new Error('API error: ' + response.statusCode + ' ' + err));
     }
+    if (!body.hasOwnProperty('response')) return callback(new Error('API error: malformed API response (no response on line)'));
     return callback(null, body.response);
   };
 }


### PR DESCRIPTION
Error thrown: 

```
TypeError: Cannot read property 'response' of undefined
    at Request._callback (T260Gtumblr/node_modules/tumblr.js/lib/tumblr.js:243:31)
    at Request.self.callback (T260Gtumblr/node_modules/tumblr.js/node_modules/request/main.js:122:22)
    at Request.EventEmitter.emit (events.js:98:17)
    at Request.<anonymous> (T260Gtumblr/node_modules/tumblr.js/node_modules/request/main.js:661:16)
    at Request.EventEmitter.emit (events.js:117:20)
    at IncomingMessage.<anonymous> (T260Gtumblr/node_modules/tumblr.js/node_modules/request/main.js:623:14)
    at IncomingMessage.EventEmitter.emit (events.js:117:20)
    at _stream_readable.js:910:16
    at process._tickCallback (node.js:415:13)
```

This patch ensures the body has a `response`, and calls back with:

``` JavaScript
new Error('API error: malformed API response (no response on line)')
```

Rather than crashing the instance.
