### PR TITLE
Support multi-image posting/external images with data field

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ client.edit(blogName, options, callback);
 // Reblog a given post
 client.reblog(blogName, options, callback);
 
-// Delete a given psot
+// Delete a given post
 client.deletePost(blogName, id, callback);
 
 // Convenience methods for creating post types
@@ -143,6 +143,20 @@ client.link(blogName, options, callback);
 client.chat(blogName, options, callback);
 client.audio(blogName, options, callback);
 client.video(blogName, options, callback);
+
+// An example photo post using the source parameter
+client.photo(blogName, {
+  caption: 'Look at this neat photo!',
+  link: 'http://nodejs.org'
+  source: 'http://nodejs.org/images/logo.png',
+}, callback);
+
+// An example photo post using the data parameter passing multiple external images
+client.photo(blogName, {
+  caption: 'Look at these neat photos!',
+  data: ['http://nodejs.org/images/logos/nodejs-green.png', 'http://nodejs.org/images/logos/nodejs-dark.png'
+}, callback);
+
 ```
 
 ### Tagged Methods

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -175,6 +175,7 @@ TumblrClient.prototype = {
   _post: function (path, params, callback) {
 
     var data = params.data;
+
     delete params.data;
 
     // Sign without multipart data
@@ -201,8 +202,18 @@ TumblrClient.prototype = {
     for (var key in params) {
       form.append(key, params[key]);
     }
+
     if (data) {
-      form.append('data', fs.createReadStream(data));
+
+      // An array can be passed for multi-image posts
+      if (Array.isArray(data)) {
+        for (var i = 0; i < data.length; i++) {
+          form.append('data[' + i + ']', filePointer(data[i]));
+        }
+      } else {
+        form.append('data', filePointer(data));
+      }
+
     }
 
     // Add the form header back
@@ -244,11 +255,13 @@ function blogPath(blogName, path) {
 function requestCallback(callback) {
   if (!callback) return undefined;
   return function (err, response, body) {
+
     if (err) return callback(err);
     if (response.statusCode >= 400) {
       var errString = body.meta ? body.meta.msg : body.error;
       return callback(new Error('API error: ' + response.statusCode + ' ' + errString));
     }
+
     if (body && body.response) {
       return callback(null, body.response);
     } else {
@@ -259,4 +272,13 @@ function requestCallback(callback) {
 
 function isFunction(value) {
   return Object.prototype.toString.call(value) == '[object Function]';
+}
+
+// Check if path is web, otherwise pull from fs
+function filePointer(path) {
+  if (path.indexOf('http://') === 0 || path.indexOf('https://') === 0) {
+    return request.get(path);
+  } else {
+    return fs.createReadStream(path);
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "name": "tumblr.js",
   "description": "Official JavaScript client for the Tumblr API",
   "homepage": "https://github.com/tumblr/tumblr.js",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "repository": {
     "url": "https://github.com/tumblr/tumblr.js"
   },

--- a/test/base_spec.js
+++ b/test/base_spec.js
@@ -1,4 +1,5 @@
 var request = require('request');
+var fs = require('fs');
 var helper = require('./helper');
 var client = helper.client;
 
@@ -61,6 +62,111 @@ describe('_get', function () {
       this.call.url.should.equal('http://api.tumblr.com/v2/the/path?my=options&api_key=consumer_key');
     });
 
+  });
+
+});
+
+describe('client', function () {
+
+  describe('.photo', function () {
+    var mockReadStreamReturn, mockRequestGetReturn;
+    function generateRandomNumberString () {
+      return Math.floor(Math.random(1000000)*100000).toString();
+    };
+
+    beforeEach(function () {
+      // Request post stub
+      request.post = function (options, callback) {
+        var self = this;
+
+        self.postCall = options;
+        self.formData = {};
+        return {
+          form: function () {
+            return {
+              append: function (appendedField, appendedData) {
+                return self.formData[appendedField] = appendedData;
+              },
+              getHeaders: function () {
+                callback(self);
+              }
+            }
+          },
+          oauth: function () {},
+          headers: {},
+          body: {}
+        };
+      }.bind(this);
+
+      // fs stub
+      mockReadStreamReturn = generateRandomNumberString();
+      fs.createReadStream = function (path) {
+        return mockReadStreamReturn;
+      };
+
+      // Request get stub
+      mockRequestGetReturn = generateRandomNumberString();
+      request.get = function (options, callback) {
+        return mockRequestGetReturn;
+      }.bind(this);
+    });
+
+    it('should make a post of type photo', function () {
+      client.photo('test', {
+        source: 'http://nodejs.org/images/logo.png'
+      }, function (requestData) {
+        requestData.formData.type.should.equal('photo');
+      });
+    });
+
+    it('should resolve blog names properly if .tumblr.com is omitted', function () {
+      client.photo('test', {
+        source: 'http://nodejs.org/images/logo.png'
+      }, function (requestData) {
+        requestData.postCall.url.indexOf('test.tumblr.com').should.not.equal(-1);
+      });
+    });
+
+    it('should make a form request with inputted caption', function () {
+      var randomCaption = generateRandomNumberString();
+      client.photo('test', {
+        caption: randomCaption,
+        source: 'http://nodejs.org/images/logo.png'
+      }, function (requestData) {
+        requestData.formData.caption.should.equal(randomCaption);
+      });
+    });
+
+    it('should pull from the local fs when not a web path', function () {
+      var randomCaption = generateRandomNumberString();
+      client.photo('test', {
+        caption: randomCaption,
+        data: './test.jpg'
+      }, function (requestData) {
+        requestData.formData.data.should.equal(mockReadStreamReturn);
+      });
+    });
+
+    it('should make a request for an image when it\'s a web path', function () {
+      var randomCaption = generateRandomNumberString();
+      client.photo('test', {
+        caption: randomCaption,
+        data: 'http://nodejs.org/images/logo.png'
+      }, function (requestData) {
+        requestData.formData.data.should.equal(mockRequestGetReturn);
+      });
+    });
+
+    it('should retrieve multiple images when an array of data is passed', function () {
+      var randomCaption = generateRandomNumberString();
+      client.photo('test', {
+        caption: randomCaption,
+        data: ['./test.jpg', 'http://nodejs.org/images/logo.png']
+      }, function (requestData) {
+        requestData.formData['data[0]'].should.equal(mockReadStreamReturn);
+        requestData.formData['data[1]'].should.equal(mockRequestGetReturn);
+      });
+    });
   });
 
 });


### PR DESCRIPTION
This adds support for multi-image posting via the data field. It also allows passing external links via request, so there isn't a limitation that the image file be available on the fs.

Without adding libraries, I wasn't really sure how to most effectively write a test for a multi-part form request, so the test just wait for `getHeaders()` to be called to execute the callback passed into `_post()` and validates the form.

If there are any suggestions, I'd be happy to revisit. I've only really played around with posting images and tried to preserve existing behavior as much as possible (so I kept the `_post` behavior of passing data instead of data[0] or converting to an array since I'm not super familiar with how the API could potentially respond).

May not need the version bump.
