### PR TITLE
Loose request version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "main": "./index",
   "dependencies": {
-    "request": "2.12.0"
+    "request": "^2.12.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Will be good to loose the dependency so that customer don't need to download multiple version of the same package and reduce the overall app package size. (`request` itself is quite large)

Major package version with breaking change should be manually update.