### PR TITLE
chore(core): use https for api calls

### DIFF
--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -21,7 +21,7 @@ module.exports = {
 
 };
 
-var baseURL = 'http://api.tumblr.com/v2';
+var baseURL = 'https://api.tumblr.com/v2';
 var version = require('../package.json').version;
 
 var calls = {

--- a/test/base_spec.js
+++ b/test/base_spec.js
@@ -21,7 +21,7 @@ describe('_get', function () {
     });
 
     it('should call with the proper url', function () {
-      this.call.url.should.equal('http://api.tumblr.com/v2' + this.path + '?my=options');
+      this.call.url.should.equal('https://api.tumblr.com/v2' + this.path + '?my=options');
     });
 
     it('should want json back', function () {
@@ -58,7 +58,7 @@ describe('_get', function () {
 
     it('should add the api key as an option', function () {
       var proper = { my: 'options', api_key: 'consumer_key' };
-      this.call.url.should.equal('http://api.tumblr.com/v2/the/path?my=options&api_key=consumer_key');
+      this.call.url.should.equal('https://api.tumblr.com/v2/the/path?my=options&api_key=consumer_key');
     });
 
   });


### PR DESCRIPTION
Making http calls to the API returns images url in http, resulting in an SSL warning on https pages.

I can of course create something make it optional, but I think that the SSL on each API request should be mandatory. Let me know if you don't agree and you prefer an option to choose this, and I'll update the PR.