### PR TITLE
Add Promise support to requests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "extends": "eslint:recommended",
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   },
 
   "parser": "espree",

--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ var client = new tumblr.Client({
 });
 ```
 
-The request methods return `Request` objects by default, but you can have it return `Promise` objects instead, if that's more your thing. Pass `true` as the second argument to `createClient`:
+The request methods return `Request` objects by default, but you can have it return `Promise` objects instead, if that's more your thing. Pass `returnPromises: true` in the options to `createClient`:
 
 ```js
 var tumblr = require('tumblr.js');
 var client = tumblr.createClient({
-  // ...
-}, true);
+  credentials: {
+    // ...
+  },
+  returnPromises: true,
+});
 ```
 
 ### In the Browser
@@ -236,7 +239,9 @@ client.addPostMethods({
     gulp lint # linter
     gulp test # just the tests
 
-# Copyright and license
+---
+
+## Copyright and license
 
 Copyright 2013-2016 Tumblr, Inc.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ var client = new tumblr.Client({
 });
 ```
 
+The request methods return `Request` objects by default, but you can have it return `Promise` objects instead, if that's more your thing. Pass `true` as the second argument to `createClient`:
+
+```js
+var tumblr = require('tumblr.js');
+var client = tumblr.createClient({
+  // ...
+}, true);
+```
+
 ### In the Browser
 
 Due to CORS restrictions, you're going to have a really hard time using this library in the browser. Although GET endpoints on the Tumblr API support JSONP, this library is not intended for in-browser use. Sorry!
@@ -73,14 +82,24 @@ client.blogPosts('staff', {type: 'photo'}, function(err, resp) {
 });
 ```
 
-In most cases, since options are optional (heh) they are also an optional
-argument, so there is no need to pass an empty object when supplying no options,
-like:
+In most cases, since options are optional (heh) they are also an optional argument, so there is no need to pass an empty object when supplying no options, like:
 
 ```js
 client.blogPosts('staff', function(err, resp) {
   resp.posts; // now we've got all kinds of posts
 });
+```
+
+If you're using Promises, use `then` and/or `catch` instead of a callback:
+
+```js
+client.blogPosts('staff')
+  .then(function(resp) {
+    resp.posts;
+  })
+  .catch(function(err) {
+    // oops
+  });
 ```
 
 ### User Methods

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -66,9 +66,11 @@ var API_METHODS = {
 /**
  * Turns a blog name to a full blog URL
  *
- * @param  {String} blogUrl: blog name or URL
+ * @param  {String} blogUrl - blog name or URL
  *
  * @return {String} full blog URL
+ *
+ * @private
  */
 function forceFullBlogUrl(blogUrl) {
     if (blogUrl.indexOf('.') < 0) {
@@ -80,11 +82,13 @@ function forceFullBlogUrl(blogUrl) {
 /**
  * Creates a named function with the desired signature
  *
- * @param  {String} name: function name
- * @param  {Array} [args]: array of argument names
- * @param  {Function} fn: function that contains the logic that should run
+ * @param  {String} name - function name
+ * @param  {Array} [args] - array of argument names
+ * @param  {Function} fn - function that contains the logic that should run
  *
  * @return {Function} a named function that takes the desired arguments
+ *
+ * @private
  */
 function createFunction(name, args, fn) {
     if (isFunction(args)) {
@@ -100,10 +104,12 @@ function createFunction(name, args, fn) {
 /**
  * Take a callback-based function and returns a Promise instead
  *
- * @param  {Function} requestMethod: callback-based method to promisify
+ * @param  {Function} requestMethod - callback-based method to promisify
  *
  * @return {Function} function that returns a Promise that resolves with the response body or
  *         rejects with the error message
+ *
+ * @private
  */
 function promisifyRequest(requestMethod) {
     return function(apiPath, params, callback) {
@@ -134,9 +140,11 @@ function promisifyRequest(requestMethod) {
 /**
  * Wraps a function for use as a request callback
  *
- * @param  {Function} callback: function to wrap
+ * @param  {Function} callback - function to wrap
  *
  * @return {Function} request callback
+ *
+ * @private
  */
 function requestCallback(callback) {
     if (!callback) {
@@ -164,15 +172,17 @@ function requestCallback(callback) {
 /**
  * Make a get request
  *
- * @param  {Function} requestGet: function that performs a get request
- * @param  {Object} credentials: OAuth credentials
- * @param  {String} baseUrl: base URL for the request
- * @param  {String} apiPath: URL path for the request
- * @param  {Object} requestOptions: additional request options
- * @param  {Object} params: query parameters
+ * @param  {Function} requestGet - function that performs a get request
+ * @param  {Object} credentials - OAuth credentials
+ * @param  {String} baseUrl - base URL for the request
+ * @param  {String} apiPath - URL path for the request
+ * @param  {Object} requestOptions - additional request options
+ * @param  {Object} params - query parameters
  * @param  {Function} callback request callback
  *
  * @return {Request} request object
+ *
+ * @private
  */
 function getRequest(requestGet, credentials, baseUrl, apiPath, requestOptions, params, callback) {
     params = params || {};
@@ -191,15 +201,17 @@ function getRequest(requestGet, credentials, baseUrl, apiPath, requestOptions, p
 /**
  * Create a function to make POST requests to the Tumblr API
  *
- * @param  {Function} requestPost: function that performs a get request
- * @param  {Object} credentials: OAuth credentials
- * @param  {String} baseUrl: base URL for the request
- * @param  {String} apiPath: URL path for the request
- * @param  {Object} requestOptions: additional request options
- * @param  {Object} params: form data
- * @param  {Function} callback request callback
+ * @param  {Function} requestPost - function that performs a get request
+ * @param  {Object} credentials - OAuth credentials
+ * @param  {String} baseUrl - base URL for the request
+ * @param  {String} apiPath - URL path for the request
+ * @param  {Object} requestOptions - additional request options
+ * @param  {Object} params - form data
+ * @param  {Function} callback - request callback
  *
  * @return {Request} request object
+ *
+ * @private
  */
 function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions, params, callback) {
     params = params || {};
@@ -243,11 +255,13 @@ function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions,
 /**
  * Adds a request method to the client
  *
- * @param  {Object} client: add the method to this object
- * @param  {String} methodName: the name of the method
- * @param  {String} apiPath: the API route, which uses any colon-prefixed segments as arguments
- * @param  {Array} paramNames: ordered list of required request parameters used as arguments
- * @param  {String|Function} requestType: the request type or a function that makes the request
+ * @param  {Object} client - add the method to this object
+ * @param  {String} methodName - the name of the method
+ * @param  {String} apiPath - the API route, which uses any colon-prefixed segments as arguments
+ * @param  {Array} paramNames - ordered list of required request parameters used as arguments
+ * @param  {String|Function} requestType - the request type or a function that makes the request
+ *
+ * @private
  */
 function addMethod(client, methodName, apiPath, paramNames, requestType) {
     var apiPathSplit = apiPath.split('/');
@@ -313,10 +327,12 @@ function addMethod(client, methodName, apiPath, paramNames, requestType) {
 /**
  * Adds methods to the client
  *
- * @param  {TumblrClient} client: an instance of the `tumblr.js` API client
- * @param  {Object} methods: mapping of method names to endpoints. Endpoints can be a string or an
+ * @param  {TumblrClient} client - an instance of the `tumblr.js` API client
+ * @param  {Object} methods - mapping of method names to endpoints. Endpoints can be a string or an
  *         array of format `[apiPathString, requireParamsArray]`
- * @param  {String|Function} requestType: the request type or a function that makes the request
+ * @param  {String|Function} requestType - the request type or a function that makes the request
+ *
+ * @private
  */
 function addMethods(client, methods, requestType) {
     var apiPath, paramNames;
@@ -338,10 +354,12 @@ function addMethods(client, methods, requestType) {
 /**
  * Wraps createPost to specify `type` and validate the parameters
  *
- * @param  {String} type: post type
- * @param  {Function} [validate]: returns `true` if the parameters validate
+ * @param  {String} type - post type
+ * @param  {Function} [validate] - returns `true` if the parameters validate
  *
  * @return {Function} wrapped function
+ *
+ * @private
  */
 function wrapCreatePost(type, validate) {
     return function(blogIdentifier, params, callback) {
@@ -380,10 +398,10 @@ function wrapCreatePost(type, validate) {
 /**
  * Creates a Tumblr API client using the given options
  *
- * @param  {Object} [options]: client options
- * @param  {Object} [options.credentials]: OAuth credentials
- * @param  {String} [options.baseUrl]: API base URL
- * @param  {Object} [options.request]: library to use for making requests
+ * @param  {Object} [options] - client options
+ * @param  {Object} [options.credentials] - OAuth credentials
+ * @param  {String} [options.baseUrl] - API base URL
+ * @param  {Object} [options.request] - library to use for making requests
  *
  * @constructor
  */
@@ -431,9 +449,9 @@ function TumblrClient(options) {
 /**
  * Performs a GET request
  *
- * @param  {String} apiPath: URL path for the request
- * @param  {Object} params: query parameters
- * @param  {Function} callback request callback
+ * @param  {String} apiPath - URL path for the request
+ * @param  {Object} params - query parameters
+ * @param  {Function} callback - request callback
  *
  * @return {Request} request object
  */
@@ -448,9 +466,9 @@ TumblrClient.prototype.getRequest = function(apiPath, params, callback) {
 /**
  * Performs a POST request
  *
- * @param  {String} apiPath: URL path for the request
- * @param  {Object} params: form parameters
- * @param  {Function} callback request callback
+ * @param  {String} apiPath - URL path for the request
+ * @param  {Object} params - form parameters
+ * @param  {Function} callback - request callback
  *
  * @return {Request} request object
  */
@@ -474,7 +492,7 @@ TumblrClient.prototype.returnPromises = function() {
 /**
  * Adds GET methods to the client
  *
- * @param  {Object} methods: mapping of method names to endpoints
+ * @param  {Object} methods - mapping of method names to endpoints
  */
 TumblrClient.prototype.addGetMethods = function(methods) {
     addMethods(this, methods, 'GET');
@@ -483,7 +501,7 @@ TumblrClient.prototype.addGetMethods = function(methods) {
 /**
  * Adds POST methods to the client
  *
- * @param  {Object} methods: mapping of method names to endpoints
+ * @param  {Object} methods - mapping of method names to endpoints
  */
 TumblrClient.prototype.addPostMethods = function(methods) {
     addMethods(this, methods, 'POST');
@@ -502,14 +520,14 @@ module.exports = {
     Client: TumblrClient,
 
     /**
-     * Creates a {@link TumblrClient} instance
+     * Creates a Tumblr Client
      *
-     * @param  {Object} [options]: client options
-     * @param  {Object} [options.credentials]: OAuth credentials
-     * @param  {String} [options.baseUrl]: API base URL
-     * @param  {Object} [options.request]: library to use for making requests
+     * @param  {Object} [options] - client options
+     * @param  {Object} [options.credentials] - OAuth credentials
+     * @param  {String} [options.baseUrl] - API base URL
+     * @param  {Object} [options.request] - library to use for making requests
      *
-     * @return {TumblrClient} instance
+     * @return {TumblrClient} {@link TumblrClient} instance
      *
      * @memberof tumblr
      * @see {@link TumblrClient}

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -15,6 +15,7 @@ var extend = require('lodash/extend');
 var reduce = require('lodash/reduce');
 var partial = require('lodash/partial');
 var zipObject = require('lodash/zipObject');
+var isBoolean = require('lodash/isBoolean');
 var isString = require('lodash/isString');
 var isFunction = require('lodash/isFunction');
 var isArray = require('lodash/isArray');
@@ -94,6 +95,42 @@ function createFunction(name, args, fn) {
     return new Function('body',
         'return function ' + name + '(' + args.join(', ') + ') { return body.apply(this, arguments); };'
     )(fn);
+}
+
+/**
+ * ## promisifyRequest
+ *
+ * Take a callback-based function and returns a Promise instead
+ *
+ * @param  {Function} requestMethod: callback-based method to promisify
+ *
+ * @return {Function} function that returns a Promise that resolves with the response body or
+ *         rejects with the error message
+ */
+function promisifyRequest(requestMethod) {
+    return function(apiPath, params, callback) {
+        var promise = new Promise(function(resolve, reject) {
+            requestMethod.call(this, apiPath, params, function(err, resp) {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(resp);
+                }
+            });
+        }.bind(this));
+
+        if (callback) {
+            promise
+                .then(function(body) {
+                    callback(null, body);
+                })
+                .catch(function(err) {
+                    callback(err, null);
+                });
+        }
+
+        return promise;
+    };
 }
 
 /**
@@ -428,6 +465,17 @@ TumblrClient.prototype.postRequest = function(apiPath, params, callback) {
 };
 
 /**
+ * ## returnPromises
+ *
+ * Sets the client to return Promises instead of Request objects by patching the `getRequest` and
+ * `postRequest` methods on the client
+ */
+TumblrClient.prototype.returnPromises = function() {
+    this.getRequest = promisifyRequest(this.getRequest);
+    this.postRequest = promisifyRequest(this.postRequest);
+};
+
+/**
  * ## addGetMethods
  *
  * Adds GET methods to the client
@@ -454,7 +502,22 @@ TumblrClient.prototype.addPostMethods = function(methods) {
  */
 module.exports = {
     Client: TumblrClient,
-    createClient: function(credentials, baseUrl) {
-        return new TumblrClient(credentials, baseUrl);
+    createClient: function(credentials, returnPromises, baseUrl, requestLibrary) {
+        // Support for `tumblr.createClient(credentials, baseUrl, requestLibrary)`
+        if (!isBoolean(returnPromises)) {
+            requestLibrary = baseUrl;
+            baseUrl = returnPromises;
+            returnPromises = false;
+        }
+
+        // Create the Tumblr Client
+        var client = new TumblrClient(credentials, baseUrl, requestLibrary);
+
+        // Patch to request methods to return Promises
+        if (returnPromises) {
+            client.returnPromises();
+        }
+
+        return client;
     },
 };

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -5,9 +5,14 @@
  *     Tumblr
  */
 
+/**
+ * @namespace tumblr
+ */
+
 var qs = require('query-string');
 var request = require('request');
 
+var get = require('lodash/get');
 var set = require('lodash/set');
 var keys = require('lodash/keys');
 var intersection = require('lodash/intersection');
@@ -15,7 +20,6 @@ var extend = require('lodash/extend');
 var reduce = require('lodash/reduce');
 var partial = require('lodash/partial');
 var zipObject = require('lodash/zipObject');
-var isBoolean = require('lodash/isBoolean');
 var isString = require('lodash/isString');
 var isFunction = require('lodash/isFunction');
 var isArray = require('lodash/isArray');
@@ -60,8 +64,6 @@ var API_METHODS = {
 };
 
 /**
- * ## forceFullBlogUrl
- *
  * Turns a blog name to a full blog URL
  *
  * @param  {String} blogUrl: blog name or URL
@@ -76,8 +78,6 @@ function forceFullBlogUrl(blogUrl) {
 }
 
 /**
- * ## createFunction
- *
  * Creates a named function with the desired signature
  *
  * @param  {String} name: function name
@@ -98,8 +98,6 @@ function createFunction(name, args, fn) {
 }
 
 /**
- * ## promisifyRequest
- *
  * Take a callback-based function and returns a Promise instead
  *
  * @param  {Function} requestMethod: callback-based method to promisify
@@ -134,8 +132,6 @@ function promisifyRequest(requestMethod) {
 }
 
 /**
- * ## requestCallback
- *
  * Wraps a function for use as a request callback
  *
  * @param  {Function} callback: function to wrap
@@ -166,8 +162,6 @@ function requestCallback(callback) {
 }
 
 /**
- * ## getRequest
- *
  * Make a get request
  *
  * @param  {Function} requestGet: function that performs a get request
@@ -195,8 +189,6 @@ function getRequest(requestGet, credentials, baseUrl, apiPath, requestOptions, p
 }
 
 /**
- * ## postRequest
- *
  * Create a function to make POST requests to the Tumblr API
  *
  * @param  {Function} requestPost: function that performs a get request
@@ -249,8 +241,6 @@ function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions,
 }
 
 /**
- * ## addMethod
- *
  * Adds a request method to the client
  *
  * @param  {Object} client: add the method to this object
@@ -321,8 +311,6 @@ function addMethod(client, methodName, apiPath, paramNames, requestType) {
 }
 
 /**
- * ## addMethods
- *
  * Adds methods to the client
  *
  * @param  {TumblrClient} client: an instance of the `tumblr.js` API client
@@ -348,8 +336,6 @@ function addMethods(client, methods, requestType) {
 }
 
 /**
- * ## wrapCreatePost
- *
  * Wraps createPost to specify `type` and validate the parameters
  *
  * @param  {String} type: post type
@@ -392,27 +378,38 @@ function wrapCreatePost(type, validate) {
 }
 
 /**
- * ## TumblrClient
+ * Creates a Tumblr API client using the given options
  *
- * Creates a Tumblr API client using the given credentials and with a specific base URL.
+ * @param  {Object} [options]: client options
+ * @param  {Object} [options.credentials]: OAuth credentials
+ * @param  {String} [options.baseUrl]: API base URL
+ * @param  {Object} [options.request]: library to use for making requests
  *
  * @constructor
- * @param  {Object} [credentials]: OAuth credentials
- * @param  {String} [baseUrl]: API base URL
- * @param  {Object} [requestLibrary]: library to use for making requests
  */
-function TumblrClient(credentials, baseUrl, requestLibrary) {
+function TumblrClient(options) {
+    // Support for `TumblrClient(credentials, baseUrl, requestLibrary)`
+    if (arguments.length > 1) {
+        options = {
+            credentials: arguments[0],
+            baseUrl: arguments[1],
+            request: arguments[2],
+            returnPromises: false,
+        };
+    }
+
+    options = options || {};
+
     this.version = CLIENT_VERSION;
-    this.credentials = credentials || {};
-    this.baseUrl = baseUrl || API_BASE_URL;
+    this.credentials = get(options, 'credentials', omit(options, 'baseUrl', 'request'));
+    this.baseUrl = get(options, 'baseUrl', API_BASE_URL);
+    this.request = get(options, 'request', request);
     this.requestOptions = {
         followRedirect: false,
         headers: {
             'User-Agent': 'tumblr.js/' + CLIENT_VERSION,
         },
     };
-
-    this.request = requestLibrary || request;
 
     this.addGetMethods(API_METHODS.GET);
     this.addPostMethods(API_METHODS.POST);
@@ -424,12 +421,15 @@ function TumblrClient(credentials, baseUrl, requestLibrary) {
     this.createChatPost = wrapCreatePost('chat', ['conversation']);
     this.createAudioPost = wrapCreatePost('audio', ['data', 'data64', 'external_url']);
     this.createVideoPost = wrapCreatePost('video', ['data', 'data64', 'embed']);
+
+    // Enable Promise mode
+    if (get(options, 'returnPromises', false)) {
+        this.returnPromises();
+    }
 }
 
 /**
- * ## getRequest
- *
- * Perform a GET request
+ * Performs a GET request
  *
  * @param  {String} apiPath: URL path for the request
  * @param  {Object} params: query parameters
@@ -446,9 +446,7 @@ TumblrClient.prototype.getRequest = function(apiPath, params, callback) {
 };
 
 /**
- * ## postRequest
- *
- * Perform a POST request
+ * Performs a POST request
  *
  * @param  {String} apiPath: URL path for the request
  * @param  {Object} params: form parameters
@@ -465,8 +463,6 @@ TumblrClient.prototype.postRequest = function(apiPath, params, callback) {
 };
 
 /**
- * ## returnPromises
- *
  * Sets the client to return Promises instead of Request objects by patching the `getRequest` and
  * `postRequest` methods on the client
  */
@@ -476,8 +472,6 @@ TumblrClient.prototype.returnPromises = function() {
 };
 
 /**
- * ## addGetMethods
- *
  * Adds GET methods to the client
  *
  * @param  {Object} methods: mapping of method names to endpoints
@@ -487,8 +481,6 @@ TumblrClient.prototype.addGetMethods = function(methods) {
 };
 
 /**
- * ## addPostMethods
- *
  * Adds POST methods to the client
  *
  * @param  {Object} methods: mapping of method names to endpoints
@@ -497,26 +489,44 @@ TumblrClient.prototype.addPostMethods = function(methods) {
     addMethods(this, methods, 'POST');
 };
 
-/**
+/*
  * Please, enjoy our luxurious exports.
  */
 module.exports = {
+    /**
+     * Passthrough for the {@link TumblrClient} class
+     *
+     * @memberof tumblr
+     * @see {@link TumblrClient}
+     */
     Client: TumblrClient,
-    createClient: function(credentials, returnPromises, baseUrl, requestLibrary) {
-        // Support for `tumblr.createClient(credentials, baseUrl, requestLibrary)`
-        if (!isBoolean(returnPromises)) {
-            requestLibrary = baseUrl;
-            baseUrl = returnPromises;
-            returnPromises = false;
+
+    /**
+     * Creates a {@link TumblrClient} instance
+     *
+     * @param  {Object} [options]: client options
+     * @param  {Object} [options.credentials]: OAuth credentials
+     * @param  {String} [options.baseUrl]: API base URL
+     * @param  {Object} [options.request]: library to use for making requests
+     *
+     * @return {TumblrClient} instance
+     *
+     * @memberof tumblr
+     * @see {@link TumblrClient}
+     */
+    createClient: function(options) {
+        // Support for `TumblrClient(credentials, baseUrl, requestLibrary)`
+        if (arguments.length > 1) {
+            options = {
+                credentials: arguments[0],
+                baseUrl: arguments[1],
+                request: arguments[2],
+                returnPromises: false,
+            };
         }
 
         // Create the Tumblr Client
-        var client = new TumblrClient(credentials, baseUrl, requestLibrary);
-
-        // Patch to request methods to return Promises
-        if (returnPromises) {
-            client.returnPromises();
-        }
+        var client = new TumblrClient(options);
 
         return client;
     },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "gulp"
   },
+  "engines": {
+    "node": ">=0.12.0"
+  },
   "homepage": "https://github.com/tumblr/tumblr.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tumblr.js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Official JavaScript client for the Tumblr API",
   "main": "./lib/tumblr",
   "scripts": {


### PR DESCRIPTION
Re: https://github.com/tumblr/tumblr.js/issues/51

This adds Promise support to API requests. Instead of getting a Request object back, you'll get a Promise, that you can `then` or `catch` or whatever cool Promise stuff you wanna do.

Part of me feels like this should be the default, but I didn't go that far. I'd rather not use [`request-promise`](https://www.npmjs.com/package/request-promise) because I don't want the `bluebird` dependency, but [`request-promise-native`](https://www.npmjs.com/package/request-promise-native) isn't a thing yet, so here we are.

---

Here's how you'd create a client that returns Promises:

```
var tumblr = require('tumblr.js');
var client = tumblr.createClient({
    credentials: credentials,
    returnPromises: true,
});
```

And here's an example of how you'd use Promises to chain requests together more easily:

```js
client.blogPosts('keithmcknight', {
    reblog_info: true,
})
    .then(function(body) {
        // let's assume the first post was a reblog
        return client.blogInfo(body.posts[0].reblogged_from_name);
    })
    .then(function(body) {
        // blog info for parent blog of the first post on the original request
        console.log(body);
    });
```

---

### TODO

* [x] Write tests
* [x] Update README
* [x] Bump version

@heylookltsme @tgilan @sndsgd @ceyko