### PR TITLE
[docs] Fixed title: createLinkPost -> createChatPost

### DIFF
--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -807,7 +807,7 @@ function TumblrClient(options) {
      *
      * @see {@link https://www.tumblr.com/docs/api/v2#pchat-posts|API docs}
      *
-     * @method createLinkPost
+     * @method createChatPost
      *
      * @param  {string} blogIdentifier - blog name or URL
      * @param  {Object} params - parameters sent with the request


### PR DESCRIPTION
Hiya, look at [the docs](https://tumblr.github.io/tumblr.js/TumblrClient.html), `createLinkPost` is listed twice, but there's no mention at all of `createChatPost`:

<img width="136" alt="screen shot 2017-07-30 at 7 57 59 pm" src="https://user-images.githubusercontent.com/33126/28755725-74c93392-7561-11e7-91c8-6f7b9283b7b0.png">

We have the power to fix this! I believe in us <3