### PR TITLE
Allow sending multiple images in a photo post

### DIFF
--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -528,6 +528,14 @@ function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions,
     delete currentRequest.headers['content-type'];
     delete currentRequest.body;
 
+    // if 'data' is an array, rename it with indices
+    if ('data' in params && Array.isArray(params.data)) {
+        for (var i = 0; i < params.data.length; ++i) {
+            params['data[' + i + ']'] = params.data[i];
+        }
+        delete params.data;
+    }
+
     // And then add the full body
     var form = currentRequest.form();
     for (var key in params) {


### PR DESCRIPTION
The docs for `createPhotoPost` say that `data` can be an array of image streams, but it does not work.
https://tumblr.github.io/tumblr.js/TumblrClient.html#.createPhotoPost

Without this change, using an array returns the error `Error: form-data: Arrays are not supported.`

Closes #24. Closes #23.

## Testing

Set the credentials and update the `blogName`, and run this script

```javascript
var tumblr = require('./lib/tumblr.js');
var request = require('request');

var client = tumblr.createClient({
    consumer_key: ...
});


var blogName = '...';

client.createPhotoPost(blogName, {
    caption: 'Look at these neat photos!',
    data: request.get('http://nodejs.org/images/logos/nodejs-dark.png'),
}, function() {
    console.log('callback', arguments);
});

client.createPhotoPost(blogName, {
    caption: 'Look at these neat photos!',
    data: [
        request.get('http://nodejs.org/images/logos/nodejs-green.png'),
        request.get('http://nodejs.org/images/logos/nodejs-dark.png'),
    ]
}, function() {
    console.log('callback', arguments);
});
```