### PR TITLE
Update compatible node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ notifications:
     - keith@tumblr.com
 language: node_js
 node_js:
-  - "5"
-  - "4"
-  - "0.12"
+  - node
+  - 8
+  - 6
+  - 4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tumblr.js",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Official JavaScript client for the Tumblr API",
   "main": "./lib/tumblr",
   "scripts": {


### PR DESCRIPTION
This other PR is failing to build on a very old version of node: https://github.com/tumblr/tumblr.js/pull/66

This PR stops travis-ci from trying to build very old versions and bumps the major version number since we are effectively removing support for 0.12

This follows the very popular `request` library:
https://github.com/request/request/blob/master/.travis.yml#L4-L8

@ceyko 