### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tumblr.js",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Official JavaScript client for the Tumblr API",
   "main": "./lib/tumblr",
   "types": "./lib/tumblr.d.ts",


### PR DESCRIPTION
As mentioned in #67, since we've dropped support for a (very) old version of node - 0.12, we should bump the major version.

See: https://github.com/tumblr/tumblr.js/pull/67