### PR TITLE
Use block-scoped variable declarations everywhere

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -274,7 +274,7 @@
     "no-restricted-imports": "off", // restrict usage of specified modules when loaded by `import` declaration
     "no-this-before-super": "error", // disallow use of `this`/`super` before calling `super()` in constructors (recommended)
     "no-useless-constructor": "off", // disallow unnecessary constructor
-    "no-var": "off", // require `let` or `const` instead of `var`
+    "no-var": "error", // require `let` or `const` instead of `var`
     "object-shorthand": "off", // require method and property shorthand syntax for object literals
     "prefer-arrow-callback": "off", // suggest using arrow functions as callbacks
     "prefer-const": "off", // suggest using `const` declaration for variables that are never reassigned after declared

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -9,27 +9,27 @@
  * @namespace tumblr
  */
 
-var qs = require('query-string');
-var request = require('request');
+const qs = require('query-string');
+const request = require('request');
 
-var get = require('lodash/get');
-var set = require('lodash/set');
-var keys = require('lodash/keys');
-var intersection = require('lodash/intersection');
-var extend = require('lodash/extend');
-var reduce = require('lodash/reduce');
-var partial = require('lodash/partial');
-var zipObject = require('lodash/zipObject');
-var isString = require('lodash/isString');
-var isFunction = require('lodash/isFunction');
-var isArray = require('lodash/isArray');
-var isPlainObject = require('lodash/isPlainObject');
-var omit = require('lodash/omit');
+const get = require('lodash/get');
+const set = require('lodash/set');
+const keys = require('lodash/keys');
+const intersection = require('lodash/intersection');
+const extend = require('lodash/extend');
+const reduce = require('lodash/reduce');
+const partial = require('lodash/partial');
+const zipObject = require('lodash/zipObject');
+const isString = require('lodash/isString');
+const isFunction = require('lodash/isFunction');
+const isArray = require('lodash/isArray');
+const isPlainObject = require('lodash/isPlainObject');
+const omit = require('lodash/omit');
 
-var CLIENT_VERSION = '1.0.0';
-var API_BASE_URL = 'https://api.tumblr.com/v2';
+const CLIENT_VERSION = '1.0.0';
+const API_BASE_URL = 'https://api.tumblr.com/v2';
 
-var API_METHODS = {
+const API_METHODS = {
     GET: {
         /**
          * Gets information about a given blog
@@ -400,7 +400,7 @@ function createFunction(name, args, fn) {
  */
 function promisifyRequest(requestMethod) {
     return function(apiPath, params, callback) {
-        var promise = new Promise(function(resolve, reject) {
+        const promise = new Promise(function(resolve, reject) {
             requestMethod.call(this, apiPath, params, function(err, resp) {
                 if (err) {
                     reject(err);
@@ -444,7 +444,7 @@ function requestCallback(callback) {
         }
 
         if (response.statusCode >= 400) {
-            var errString = body.meta ? body.meta.msg : body.error;
+            const errString = body.meta ? body.meta.msg : body.error;
             return callback(new Error('API error: ' + response.statusCode + ' ' + errString), null, response);
         }
 
@@ -504,7 +504,7 @@ function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions,
     params = params || {};
 
     // Sign without multipart data
-    var currentRequest = requestPost(extend({
+    const currentRequest = requestPost(extend({
         url: baseUrl + apiPath,
         oauth: credentials,
     }, requestOptions), function(err, response, body) {
@@ -519,7 +519,7 @@ function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions,
     });
 
     // Sign it with the non-data parameters
-    var dataKeys = ['data'];
+    const dataKeys = ['data'];
     currentRequest.form(omit(params, dataKeys));
     currentRequest.oauth(credentials);
 
@@ -529,15 +529,15 @@ function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions,
 
     // if 'data' is an array, rename it with indices
     if ('data' in params && Array.isArray(params.data)) {
-        for (var i = 0; i < params.data.length; ++i) {
+        for (let i = 0; i < params.data.length; ++i) {
             params['data[' + i + ']'] = params.data[i];
         }
         delete params.data;
     }
 
     // And then add the full body
-    var form = currentRequest.form();
-    for (var key in params) {
+    const form = currentRequest.form();
+    for (const key in params) {
         form.append(key, params[key]);
     }
 
@@ -559,11 +559,11 @@ function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions,
  * @private
  */
 function addMethod(client, methodName, apiPath, paramNames, requestType) {
-    var apiPathSplit = apiPath.split('/');
-    var apiPathParamsCount = apiPath.split(/\/:[^\/]+/).length - 1;
+    const apiPathSplit = apiPath.split('/');
+    const apiPathParamsCount = apiPath.split(/\/:[^\/]+/).length - 1;
 
-    var buildApiPath = function(args) {
-        var pathParamIndex = 0;
+    const buildApiPath = function(args) {
+        let pathParamIndex = 0;
         return reduce(apiPathSplit, function(apiPath, apiPathChunk, i) {
             // Parse arguments in the path
             if (apiPathChunk === ':blogIdentifier') {
@@ -581,32 +581,32 @@ function addMethod(client, methodName, apiPath, paramNames, requestType) {
         }, '');
     };
 
-    var namedParams = (apiPath.match(/\/:[^\/]+/g) || []).map(function(param) {
+    const namedParams = (apiPath.match(/\/:[^\/]+/g) || []).map(function(param) {
         return param.substr(2);
     }).concat(paramNames, 'params', 'callback');
 
-    var methodBody = function() {
-        var argsLength = arguments.length;
-        var args = new Array(argsLength);
-        for (var i = 0; i < argsLength; i++) {
+    const methodBody = function() {
+        const argsLength = arguments.length;
+        const args = new Array(argsLength);
+        for (let i = 0; i < argsLength; i++) {
             args[i] = arguments[i];
         }
 
-        var requiredParamsStart = apiPathParamsCount;
-        var requiredParamsEnd = requiredParamsStart + paramNames.length;
-        var requiredParamArgs = args.slice(requiredParamsStart, requiredParamsEnd);
+        const requiredParamsStart = apiPathParamsCount;
+        const requiredParamsEnd = requiredParamsStart + paramNames.length;
+        const requiredParamArgs = args.slice(requiredParamsStart, requiredParamsEnd);
 
         // Callback is at the end
-        var callback = isFunction(args[args.length - 1]) ? args.pop() : null;
+        const callback = isFunction(args[args.length - 1]) ? args.pop() : null;
 
         // Required Parmas
-        var params = zipObject(paramNames, requiredParamArgs);
+        const params = zipObject(paramNames, requiredParamArgs);
         extend(params, isPlainObject(args[args.length - 1]) ? args.pop() : {});
 
         // Path arguments are determined after required parameters
-        var apiPathArgs = args.slice(0, apiPathParamsCount);
+        const apiPathArgs = args.slice(0, apiPathParamsCount);
 
-        var request = requestType;
+        let request = requestType;
         if (isString(requestType)) {
             request = requestType.toUpperCase() === 'POST' ? client.postRequest : client.getRequest;
         } else if (!isFunction(requestType)) {
@@ -630,8 +630,8 @@ function addMethod(client, methodName, apiPath, paramNames, requestType) {
  * @private
  */
 function addMethods(client, methods, requestType) {
-    var apiPath, paramNames;
-    for (var methodName in methods) {
+    let apiPath, paramNames;
+    for (const methodName in methods) {
         apiPath = methods[methodName];
         if (isString(apiPath)) {
             paramNames = [];
@@ -663,7 +663,7 @@ function wrapCreatePost(type, validate) {
         if (isArray(validate)) {
             validate = partial(function(params, requireKeys) {
                 if (requireKeys.length) {
-                    var keyIntersection = intersection(keys(params), requireKeys);
+                    const keyIntersection = intersection(keys(params), requireKeys);
                     if (requireKeys.length === 1 && !keyIntersection.length) {
                         throw new Error('Missing required field: ' + requireKeys[0]);
                     } else if (!keyIntersection.length) {
@@ -981,7 +981,7 @@ module.exports = {
         }
 
         // Create the Tumblr Client
-        var client = new TumblrClient(options);
+        const client = new TumblrClient(options);
 
         return client;
     },

--- a/test/tumblr.test.js
+++ b/test/tumblr.test.js
@@ -34,7 +34,6 @@ describe('tumblr.js', function() {
 
     describe('createClient', function() {
         var tumblr = require('../lib/tumblr.js');
-        var client;
 
         it('creates a TumblrClient instance', function() {
             assert.isFunction(tumblr.createClient);
@@ -46,7 +45,7 @@ describe('tumblr.js', function() {
             var credentials = DUMMY_CREDENTIALS;
 
             // tumblr.createClient(credentials, baseUrl, requestLibrary)
-            client = tumblr.createClient(credentials);
+            var client = tumblr.createClient(credentials);
             assert.equal(client.credentials.consumer_key, credentials.consumer_key);
             assert.equal(client.credentials.consumer_secret, credentials.consumer_secret);
             assert.equal(client.credentials.token, credentials.token);
@@ -64,7 +63,7 @@ describe('tumblr.js', function() {
             var baseUrl = 'https://t.umblr.com/v2';
 
             // tumblr.createClient(credentials, baseUrl, requestLibrary)
-            client = tumblr.createClient({}, baseUrl);
+            var client = tumblr.createClient({}, baseUrl);
             assert.equal(client.baseUrl, baseUrl);
 
             // tumblr.createClient(options)
@@ -73,7 +72,6 @@ describe('tumblr.js', function() {
         });
 
         it('passes requestLibrary to the client', function() {
-            var client;
             var requestLibrary = {
                 get: function(options, callback) {
                     return callback(options);
@@ -84,30 +82,21 @@ describe('tumblr.js', function() {
             };
 
             // TumblrClient(options)
-            client = tumblr.createClient({request: requestLibrary});
+            var client = tumblr.createClient({request: requestLibrary});
             assert.equal(client.request, requestLibrary);
         });
 
         it('passes returnPromises to the client', function() {
             // tumblr.createClient(options)
-            client = tumblr.createClient({returnPromises: true});
+            var client = tumblr.createClient({returnPromises: true});
             assert.notEqual(client.getRequest, tumblr.Client.prototype.getRequest);
             assert.notEqual(client.postRequest, tumblr.Client.prototype.postRequest);
         });
     });
 
     describe('Client', function() {
-        var client;
         var tumblr = require('../lib/tumblr.js');
         var TumblrClient = tumblr.Client;
-
-        beforeEach(function() {
-            client = new TumblrClient({
-                credentials: DUMMY_CREDENTIALS,
-                baseUrl: DUMMY_API_URL,
-                returnPromises: false,
-            });
-        });
 
         describe('constructor', function() {
             it('creates a TumblrClient instance', function() {
@@ -168,10 +157,8 @@ describe('tumblr.js', function() {
             });
 
             it('uses the supplied returnPromises value', function() {
-                var client;
-
                 // tumblr.createClient(options)
-                client = tumblr.createClient({returnPromises: false});
+                var client = tumblr.createClient({returnPromises: false});
                 assert.equal(client.getRequest, tumblr.Client.prototype.getRequest);
                 assert.equal(client.postRequest, tumblr.Client.prototype.postRequest);
 
@@ -212,6 +199,14 @@ describe('tumblr.js', function() {
             });
         });
 
+        var client;
+        beforeEach(function() {
+            client = new TumblrClient({
+                credentials: DUMMY_CREDENTIALS,
+                baseUrl: DUMMY_API_URL,
+                returnPromises: false,
+            });
+        });
 
         /**
          * ## Default methods

--- a/test/tumblr.test.js
+++ b/test/tumblr.test.js
@@ -1,26 +1,26 @@
-var fs = require('fs');
-var path = require('path');
+const fs = require('fs');
+const path = require('path');
 
-var JSON5 = require('json5');
-var qs = require('query-string');
-var forEach = require('lodash/forEach');
-var lowerCase = require('lodash/lowerCase');
+const JSON5 = require('json5');
+const qs = require('query-string');
+const forEach = require('lodash/forEach');
+const lowerCase = require('lodash/lowerCase');
 
-var assert = require('chai').assert;
-var nock = require('nock');
+const assert = require('chai').assert;
+const nock = require('nock');
 
-var DUMMY_CREDENTIALS = {
+const DUMMY_CREDENTIALS = {
     consumer_key: 'Mario',
     consumer_secret: 'Luigi',
     token: 'Toad',
     token_secret: 'Princess Toadstool',
 };
-var DUMMY_API_URL = 'https://t.umblr.com/v2';
+const DUMMY_API_URL = 'https://t.umblr.com/v2';
 
-var URL_PARAM_REGEX = /\/:([^\/]+)/g;
+const URL_PARAM_REGEX = /\/:([^\/]+)/g;
 
 function createQueryString(obj) {
-    var queryString = qs.stringify(obj);
+    const queryString = qs.stringify(obj);
     return queryString ? '?' + queryString : '';
 }
 
@@ -33,19 +33,19 @@ describe('tumblr.js', function() {
     });
 
     describe('createClient', function() {
-        var tumblr = require('../lib/tumblr.js');
+        const tumblr = require('../lib/tumblr.js');
 
         it('creates a TumblrClient instance', function() {
             assert.isFunction(tumblr.createClient);
-            var client = tumblr.createClient();
+            const client = tumblr.createClient();
             assert.isTrue(client instanceof tumblr.Client);
         });
 
         it('passes credentials to the client', function() {
-            var credentials = DUMMY_CREDENTIALS;
+            const credentials = DUMMY_CREDENTIALS;
 
             // tumblr.createClient(credentials, baseUrl, requestLibrary)
-            var client = tumblr.createClient(credentials);
+            let client = tumblr.createClient(credentials);
             assert.equal(client.credentials.consumer_key, credentials.consumer_key);
             assert.equal(client.credentials.consumer_secret, credentials.consumer_secret);
             assert.equal(client.credentials.token, credentials.token);
@@ -60,10 +60,10 @@ describe('tumblr.js', function() {
         });
 
         it('passes baseUrl to the client', function() {
-            var baseUrl = 'https://t.umblr.com/v2';
+            const baseUrl = 'https://t.umblr.com/v2';
 
             // tumblr.createClient(credentials, baseUrl, requestLibrary)
-            var client = tumblr.createClient({}, baseUrl);
+            let client = tumblr.createClient({}, baseUrl);
             assert.equal(client.baseUrl, baseUrl);
 
             // tumblr.createClient(options)
@@ -72,7 +72,7 @@ describe('tumblr.js', function() {
         });
 
         it('passes requestLibrary to the client', function() {
-            var requestLibrary = {
+            const requestLibrary = {
                 get: function(options, callback) {
                     return callback(options);
                 },
@@ -82,31 +82,31 @@ describe('tumblr.js', function() {
             };
 
             // TumblrClient(options)
-            var client = tumblr.createClient({request: requestLibrary});
+            const client = tumblr.createClient({request: requestLibrary});
             assert.equal(client.request, requestLibrary);
         });
 
         it('passes returnPromises to the client', function() {
             // tumblr.createClient(options)
-            var client = tumblr.createClient({returnPromises: true});
+            const client = tumblr.createClient({returnPromises: true});
             assert.notEqual(client.getRequest, tumblr.Client.prototype.getRequest);
             assert.notEqual(client.postRequest, tumblr.Client.prototype.postRequest);
         });
     });
 
     describe('Client', function() {
-        var tumblr = require('../lib/tumblr.js');
-        var TumblrClient = tumblr.Client;
+        const tumblr = require('../lib/tumblr.js');
+        const TumblrClient = tumblr.Client;
 
         describe('constructor', function() {
             it('creates a TumblrClient instance', function() {
-                var client = new TumblrClient();
+                const client = new TumblrClient();
                 assert.isTrue(client instanceof TumblrClient);
             });
 
             it('uses the supplied credentials', function() {
-                var client;
-                var credentials = DUMMY_CREDENTIALS;
+                let client;
+                const credentials = DUMMY_CREDENTIALS;
 
                 // TumblrClient(credentials, baseUrl, requestLibrary)
                 client = new TumblrClient(credentials);
@@ -124,8 +124,8 @@ describe('tumblr.js', function() {
             });
 
             it('uses the supplied baseUrl', function() {
-                var client;
-                var baseUrl = DUMMY_API_URL;
+                let client;
+                const baseUrl = DUMMY_API_URL;
 
                 // TumblrClient(credentials, baseUrl, requestLibrary)
                 client = tumblr.createClient({}, baseUrl);
@@ -137,8 +137,8 @@ describe('tumblr.js', function() {
             });
 
             it('uses the supplied requestLibrary', function() {
-                var client;
-                var requestLibrary = {
+                let client;
+                const requestLibrary = {
                     get: function(options, callback) {
                         return callback(options);
                     },
@@ -158,7 +158,7 @@ describe('tumblr.js', function() {
 
             it('uses the supplied returnPromises value', function() {
                 // tumblr.createClient(options)
-                var client = tumblr.createClient({returnPromises: false});
+                let client = tumblr.createClient({returnPromises: false});
                 assert.equal(client.getRequest, tumblr.Client.prototype.getRequest);
                 assert.equal(client.postRequest, tumblr.Client.prototype.postRequest);
 
@@ -170,17 +170,17 @@ describe('tumblr.js', function() {
 
             describe('default options', function() {
                 it('uses the default Tumblr API base URL', function() {
-                    var client = tumblr.createClient();
+                    const client = tumblr.createClient();
                     assert.equal(client.baseUrl, 'https://api.tumblr.com/v2');
                 });
 
                 it('uses default request library', function() {
-                    var client = tumblr.createClient();
+                    const client = tumblr.createClient();
                     assert.equal(client.request, require('request'));
                 });
 
                 it('does not return Promises', function() {
-                    var client = tumblr.createClient();
+                    const client = tumblr.createClient();
                     assert.equal(client.getRequest, tumblr.Client.prototype.getRequest);
                     assert.equal(client.postRequest, tumblr.Client.prototype.postRequest);
                 });
@@ -190,16 +190,16 @@ describe('tumblr.js', function() {
 
         describe('#returnPromises', function() {
             it('modifies getRequest and postRequest', function() {
-                var client = new TumblrClient();
-                var getRequestBefore = client.getRequest;
-                var postRequestBefore = client.postRequest;
+                const client = new TumblrClient();
+                const getRequestBefore = client.getRequest;
+                const postRequestBefore = client.postRequest;
                 client.returnPromises();
                 assert.notEqual(getRequestBefore, client.getRequest);
                 assert.notEqual(postRequestBefore, client.postRequest);
             });
         });
 
-        var client;
+        let client;
         beforeEach(function() {
             client = new TumblrClient({
                 credentials: DUMMY_CREDENTIALS,
@@ -215,7 +215,7 @@ describe('tumblr.js', function() {
          */
 
         describe('default methods', function() {
-            var defaulthMethods = [
+            const defaulthMethods = [
                 'blogInfo',
                 'blogAvatar',
                 'blogLikes',
@@ -264,7 +264,7 @@ describe('tumblr.js', function() {
          */
 
         function setupNockBeforeAfter(httpMethod, data, apiPath) {
-            var queryParams, testApiPath;
+            let queryParams, testApiPath;
 
             before(function() {
                 queryParams = {};
@@ -293,7 +293,7 @@ describe('tumblr.js', function() {
             post: 'postRequest',
         }, function(clientMethod, httpMethod) {
             describe('#' + clientMethod, function() {
-                var fixtures = JSON5.parse(fs.readFileSync(path.join(__dirname, 'fixtures/' + httpMethod + '.json5')).toString());
+                const fixtures = JSON5.parse(fs.readFileSync(path.join(__dirname, 'fixtures/' + httpMethod + '.json5')).toString());
 
                 /**
                  * ### Callback
@@ -302,9 +302,9 @@ describe('tumblr.js', function() {
                 describe('returnPromises disabled', function() {
                     forEach(fixtures, function(data, apiPath) {
                         describe(apiPath, function() {
-                            var callbackInvoked, requestError, requestResponse, returnValue;
-                            var params = {};
-                            var callback = function(err, resp) {
+                            let callbackInvoked, requestError, requestResponse, returnValue;
+                            const params = {};
+                            const callback = function(err, resp) {
                                 callbackInvoked = true;
                                 requestError = err;
                                 requestResponse = resp;
@@ -383,13 +383,13 @@ describe('tumblr.js', function() {
                         post: 'postRequest',
                     }, function(clientMethod, httpMethod) {
                         describe('#' + clientMethod, function() {
-                            var fixtures = JSON5.parse(fs.readFileSync(path.join(__dirname, 'fixtures/' + httpMethod + '.json5')).toString());
+                            const fixtures = JSON5.parse(fs.readFileSync(path.join(__dirname, 'fixtures/' + httpMethod + '.json5')).toString());
 
                             forEach(fixtures, function(data, apiPath) {
                                 describe(apiPath, function() {
-                                    var callbackInvoked, requestError, requestResponse, returnValue;
-                                    var params = {};
-                                    var callback = function(err, resp) {
+                                    let callbackInvoked, requestError, requestResponse, returnValue;
+                                    const params = {};
+                                    const callback = function(err, resp) {
                                         callbackInvoked = true;
                                         requestError = err;
                                         requestResponse = resp;
@@ -450,7 +450,7 @@ describe('tumblr.js', function() {
             post: 'addPostMethods',
         }, function(clientMethod, httpMethod) {
             describe('#' + clientMethod, function() {
-                var data = {
+                const data = {
                     meta: {
                         status: 200,
                         msg: 'k',
@@ -462,7 +462,7 @@ describe('tumblr.js', function() {
                     },
                 };
 
-                var addMethods = {
+                const addMethods = {
                     testNoPathParameters: '/no/params',
                     testOnePathParameter: '/one/:url/param',
                     testTwoPathParameters: '/one/:url/param',
@@ -476,15 +476,15 @@ describe('tumblr.js', function() {
 
                 forEach(addMethods, function(apiPath, methodName) {
                     describe(lowerCase(methodName).replace(/^test /i, ''), function() {
-                        var callbackInvoked, requestError, requestResponse;
-                        var params = {};
-                        var callback = function(err, resp) {
+                        let callbackInvoked, requestError, requestResponse;
+                        const params = {};
+                        const callback = function(err, resp) {
                             callbackInvoked = true;
                             requestError = err;
                             requestResponse = resp;
                         };
-                        var queryParams = {};
-                        var args = [];
+                        const queryParams = {};
+                        const args = [];
 
                         if (typeof apiPath === 'string') {
                             forEach(apiPath.match(URL_PARAM_REGEX), function(apiPathParam) {
@@ -513,7 +513,7 @@ describe('tumblr.js', function() {
                                 queryParams.api_key = client.credentials.consumer_key;
                             }
 
-                            var testApiPath = apiPath;
+                            let testApiPath = apiPath;
                             if (httpMethod === 'get') {
                                 testApiPath += createQueryString(queryParams);
                             }


### PR DESCRIPTION
Since the project moved to node 6 being the minimum supported version, I thought we should use more "modern" javascript features and move away from the `var` statement and it's weird behavior. This PR changes all `var` statements into `let` and `const` statements.

For reference:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const