### PR TITLE
Add compatibility with Tumblr API links objects being passed through to these low level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,19 +217,19 @@ In the unlikely event that we add a bunch of methods to the API docs and don't u
 // GET methods
 client.addGetMethods({
   // creates client.userInfo(params, callback)
-  userInfo: '/user/info',
+  userInfo: '/v2/user/info',
   // client.blogInfo(blogIdentifier, params, callback)
-  blogInfo: '/blog/:blogIdentifier/info',
+  blogInfo: '/v2/blog/:blogIdentifier/info',
   // Creates client.taggedPosts(tag, params, callback)
-  taggedPosts: ['/tagged', ['tag']],
+  taggedPosts: ['/v2/tagged', ['tag']],
 });
 
 // POST methods
 client.addPostMethods({
   // client.deletePost(blogIdentifier, id, params, callback)
-  deletePost: ['/blog/:blogIdentifier/post/delete', ['id']],
+  deletePost: ['/v2/blog/:blogIdentifier/post/delete', ['id']],
   // Creates client.likePost(tag, id, reblog_key, params, callback)
-  likePost: ['/user/like', ['id', 'reblog_key']],
+  likePost: ['/v2/user/like', ['id', 'reblog_key']],
 });
 ```
 

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -11,6 +11,7 @@
 
 const qs = require('query-string');
 const request = require('request');
+const URL = require('url').URL;
 
 const get = require('lodash/get');
 const set = require('lodash/set');
@@ -728,6 +729,18 @@ function TumblrClient(options) {
     this.version = CLIENT_VERSION;
     this.credentials = get(options, 'credentials', omit(options, 'baseUrl', 'request'));
     this.baseUrl = get(options, 'baseUrl', API_BASE_URL);
+
+    // if someone is providing a custom baseUrl with a path, show a message
+    // to help them debug if they run into errors.
+    if (this.baseUrl !== API_BASE_URL) {
+        const baseUrl = new URL(this.baseUrl);
+        if (baseUrl.pathname !== '') {
+            console.warn('WARNING! Path detected in your custom baseUrl!');
+            console.warn('As of version 3.0.0, tumblr.js no longer includes a path in the baseUrl.');
+            console.warn('If you encounter errors, please try to omit the path.');
+        }
+    }
+
     this.request = get(options, 'request', request);
     this.requestOptions = {
         followRedirect: false,

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -735,9 +735,11 @@ function TumblrClient(options) {
     if (this.baseUrl !== API_BASE_URL) {
         const baseUrl = new URL(this.baseUrl);
         if (baseUrl.pathname !== '') {
+            /* eslint-disable no-console */
             console.warn('WARNING! Path detected in your custom baseUrl!');
             console.warn('As of version 3.0.0, tumblr.js no longer includes a path in the baseUrl.');
             console.warn('If you encounter errors, please try to omit the path.');
+            /* eslint-enable no-console */
         }
     }
 

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -26,8 +26,8 @@ const isArray = require('lodash/isArray');
 const isPlainObject = require('lodash/isPlainObject');
 const omit = require('lodash/omit');
 
-const CLIENT_VERSION = '1.0.0';
-const API_BASE_URL = 'https://api.tumblr.com/v2';
+const CLIENT_VERSION = '3.0.0';
+const API_BASE_URL = 'https://api.tumblr.com'; // deliberately no trailing slash
 
 const API_METHODS = {
     GET: {
@@ -44,7 +44,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        blogInfo: '/blog/:blogIdentifier/info',
+        blogInfo: '/v2/blog/:blogIdentifier/info',
 
         /**
          * Gets the avatar URL for a blog
@@ -60,7 +60,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        blogAvatar: '/blog/:blogIdentifier/avatar/:size',
+        blogAvatar: '/v2/blog/:blogIdentifier/avatar/:size',
 
         /**
          * Gets the likes for a blog
@@ -75,7 +75,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        blogLikes: '/blog/:blogIdentifier/likes',
+        blogLikes: '/v2/blog/:blogIdentifier/likes',
 
         /**
          * Gets the followers for a blog
@@ -90,7 +90,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        blogFollowers: '/blog/:blogIdentifier/followers',
+        blogFollowers: '/v2/blog/:blogIdentifier/followers',
 
         /**
          * Gets a list of posts for a blog
@@ -104,7 +104,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        blogPosts: '/blog/:blogIdentifier/posts/:type',
+        blogPosts: '/v2/blog/:blogIdentifier/posts/:type',
 
         /**
          * Gets the queue for a blog
@@ -119,7 +119,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        blogQueue: '/blog/:blogIdentifier/posts/queue',
+        blogQueue: '/v2/blog/:blogIdentifier/posts/queue',
 
         /**
          * Gets the drafts for a blog
@@ -134,7 +134,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        blogDrafts: '/blog/:blogIdentifier/posts/draft',
+        blogDrafts: '/v2/blog/:blogIdentifier/posts/draft',
 
         /**
          * Gets the submissions for a blog
@@ -149,7 +149,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        blogSubmissions: '/blog/:blogIdentifier/posts/submission',
+        blogSubmissions: '/v2/blog/:blogIdentifier/posts/submission',
 
         /**
          * Gets information about the authenticating user and their blogs
@@ -163,7 +163,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        userInfo: '/user/info',
+        userInfo: '/v2/user/info',
 
         /**
          * Gets the dashboard posts for the authenticating user
@@ -177,7 +177,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        userDashboard: '/user/dashboard',
+        userDashboard: '/v2/user/dashboard',
 
         /**
          * Gets the blogs the authenticating user follows
@@ -191,7 +191,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        userFollowing: '/user/following',
+        userFollowing: '/v2/user/following',
 
         /**
          * Gets the likes for the authenticating user
@@ -205,7 +205,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        userLikes: '/user/likes',
+        userLikes: '/v2/user/likes',
 
         /**
          * Gets posts tagged with the specified tag
@@ -220,7 +220,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        taggedPosts: ['/tagged', ['tag']],
+        taggedPosts: ['/v2/tagged', ['tag']],
     },
 
     POST: {
@@ -238,7 +238,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        createPost: '/blog/:blogIdentifier/post',
+        createPost: '/v2/blog/:blogIdentifier/post',
 
         /**
          * Edits a given post
@@ -253,7 +253,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        editPost: '/blog/:blogIdentifier/post/edit',
+        editPost: '/v2/blog/:blogIdentifier/post/edit',
 
         /**
          * Edits a given post
@@ -268,7 +268,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        reblogPost: '/blog/:blogIdentifier/post/reblog',
+        reblogPost: '/v2/blog/:blogIdentifier/post/reblog',
 
         /**
          * Edits a given post
@@ -284,7 +284,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        deletePost: ['/blog/:blogIdentifier/post/delete', ['id']],
+        deletePost: ['/v2/blog/:blogIdentifier/post/delete', ['id']],
 
         /**
          * Follows a blog as the authenticating user
@@ -299,7 +299,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        followBlog: ['/user/follow', ['url']],
+        followBlog: ['/v2/user/follow', ['url']],
 
         /**
          * Unfollows a blog as the authenticating user
@@ -314,7 +314,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        unfollowBlog: ['/user/unfollow', ['url']],
+        unfollowBlog: ['/v2/user/unfollow', ['url']],
 
         /**
          * Likes a post as the authenticating user
@@ -330,7 +330,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        likePost: ['/user/like', ['id', 'reblog_key']],
+        likePost: ['/v2/user/like', ['id', 'reblog_key']],
 
         /**
          * Unlikes a post as the authenticating user
@@ -346,7 +346,7 @@ const API_METHODS = {
          *
          * @memberof TumblrClient
          */
-        unlikePost: ['/user/unlike', ['id', 'reblog_key']],
+        unlikePost: ['/v2/user/unlike', ['id', 'reblog_key']],
     },
 };
 
@@ -478,11 +478,6 @@ function getRequest(requestGet, credentials, baseUrl, apiPath, requestOptions, p
         params.api_key = credentials.consumer_key;
     }
 
-    // if given an apiPath already with the API version prefix, i.e. /v2/user/info, remove the /v2
-    if (apiPath.substr(0, 3) === '/v2') {
-        apiPath = apiPath.substr(3);
-    }
-
     // if the apiPath already has query params, use them
     let existingQueryIndex = apiPath.indexOf('?');
     if (existingQueryIndex !== -1) {
@@ -519,11 +514,6 @@ function getRequest(requestGet, credentials, baseUrl, apiPath, requestOptions, p
  */
 function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions, params, callback) {
     params = params || {};
-
-    // if given an apiPath already with the API version prefix, i.e. /v2/user/info, remove the /v2
-    if (apiPath.substr(0, 3) === '/v2') {
-        apiPath = apiPath.substr(3);
-    }
 
     // Sign without multipart data
     const currentRequest = requestPost(extend({

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -478,6 +478,23 @@ function getRequest(requestGet, credentials, baseUrl, apiPath, requestOptions, p
         params.api_key = credentials.consumer_key;
     }
 
+    // if given /v2/user/info, remove the /v2
+    if (apiPath.substr(0, 3) === '/v2') {
+        apiPath = apiPath.substr(3);
+    }
+
+    // if the apiPath already has query params, use them
+    let existingQueryIndex = apiPath.indexOf('?');
+    if (existingQueryIndex !== -1) {
+        let existingParams = qs.parse(apiPath.substr(existingQueryIndex));
+
+        // extend the existing params with the given params
+        extend(existingParams, params);
+
+        // reset the given apiPath to remove those query params for clean reassembly
+        apiPath = apiPath.substring(0, existingQueryIndex);
+    }
+
     return requestGet(extend({
         url: baseUrl + apiPath + '?' + qs.stringify(params),
         oauth: credentials,

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -520,6 +520,11 @@ function getRequest(requestGet, credentials, baseUrl, apiPath, requestOptions, p
 function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions, params, callback) {
     params = params || {};
 
+    // if given /v2/user/info, remove the /v2
+    if (apiPath.substr(0, 3) === '/v2') {
+        apiPath = apiPath.substr(3);
+    }
+
     // Sign without multipart data
     const currentRequest = requestPost(extend({
         url: baseUrl + apiPath,

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -732,9 +732,9 @@ function TumblrClient(options) {
 
     // if someone is providing a custom baseUrl with a path, show a message
     // to help them debug if they run into errors.
-    if (this.baseUrl !== API_BASE_URL) {
+    if (this.baseUrl !== API_BASE_URL && this.baseUrl !== '') {
         const baseUrl = new URL(this.baseUrl);
-        if (baseUrl.pathname !== '') {
+        if (baseUrl.pathname !== '/') {
             /* eslint-disable no-console */
             console.warn('WARNING! Path detected in your custom baseUrl!');
             console.warn('As of version 3.0.0, tumblr.js no longer includes a path in the baseUrl.');

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -478,7 +478,7 @@ function getRequest(requestGet, credentials, baseUrl, apiPath, requestOptions, p
         params.api_key = credentials.consumer_key;
     }
 
-    // if given /v2/user/info, remove the /v2
+    // if given an apiPath already with the API version prefix, i.e. /v2/user/info, remove the /v2
     if (apiPath.substr(0, 3) === '/v2') {
         apiPath = apiPath.substr(3);
     }
@@ -520,7 +520,7 @@ function getRequest(requestGet, credentials, baseUrl, apiPath, requestOptions, p
 function postRequest(requestPost, credentials, baseUrl, apiPath, requestOptions, params, callback) {
     params = params || {};
 
-    // if given /v2/user/info, remove the /v2
+    // if given an apiPath already with the API version prefix, i.e. /v2/user/info, remove the /v2
     if (apiPath.substr(0, 3) === '/v2') {
         apiPath = apiPath.substr(3);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tumblr.js",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Official JavaScript client for the Tumblr API",
   "main": "./lib/tumblr",
   "types": "./lib/tumblr.d.ts",

--- a/test/tumblr.test.js
+++ b/test/tumblr.test.js
@@ -171,7 +171,7 @@ describe('tumblr.js', function() {
             describe('default options', function() {
                 it('uses the default Tumblr API base URL', function() {
                     const client = tumblr.createClient();
-                    assert.equal(client.baseUrl, 'https://api.tumblr.com/v2');
+                    assert.equal(client.baseUrl, 'https://api.tumblr.com');
                 });
 
                 it('uses default request library', function() {

--- a/test/tumblr.test.js
+++ b/test/tumblr.test.js
@@ -15,7 +15,7 @@ const DUMMY_CREDENTIALS = {
     token: 'Toad',
     token_secret: 'Princess Toadstool',
 };
-const DUMMY_API_URL = 'https://t.umblr.com/v2';
+const DUMMY_API_URL = 'https://t.umblr.com';
 
 const URL_PARAM_REGEX = /\/:([^\/]+)/g;
 


### PR DESCRIPTION
See https://github.com/tumblr/tumblr.js/issues/99 for some backstory.

tl;dr you should be able to do this cleanly: `tumblr.getRequest(response._links.next.href);` when `response._links.next` is one of the links objects from [our API](https://github.com/tumblr/docs/blob/master/api.md#links).

This is a tricky one (though that's not really obvious) for a few reasons:

1. The `tumblr.js` library sets the base URL to include `/v2`: https://github.com/tumblr/tumblr.js/blob/master/lib/tumblr.js#L30
2. The `tumblr.js` library also assumes that the given `apiPath` never has existing query params, which is true for the helper methods we're including, but not necessarily true if you want to dive all the way down to `tumblr.getRequest` itself.
3. In the Tumblr backend, we do not assume the client is doing either of these things, so we supply the full URL path and query string parameters for `GET` requests.

We can't reasonably change the third point on the backend; I'd rather the backend _not_ change its behavior based on the client, and instead fix this at the `tumblr.js` framework level, since we're baking assumptions in there for its specific use case. That feels like the right move here but I'm open to other possibilities. I flirted with the idea of adding a `path` field in the backend for all of these `links` objects, but this would bloat... just about every response size we serve, when it's fairly standard to have a means on the consumer side to parse that `href`, as I'm doing here.

Thoughts? @shahkashani @sndsgd 