### PR TITLE
remove contributor license agreement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,19 +8,7 @@ We want to make contributing to `tumblr.js` as easy and transparent as possible.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
-5. If you haven't already, complete the Contributor License Agreement ("CLA").
-
-## Contributor License Agreement ("CLA")
-
-In order to accept your contribution, we need you to submit a CLA. If you open
-a pull request, a bot will automatically check if you have already submitted
-one. If not it will ask you to do so by visiting a link and signing in with
-GitHub.
-
-The CLA, contact information, and GitHub sign-in can be found here:
-[https://yahoocla.herokuapp.com](https://yahoocla.herokuapp.com).
 
 ## License
 
 By contributing to tumblr.js you agree that your contributions will be licensed under its Apache 2.0 license.
-


### PR DESCRIPTION
We don't need the CLA anymore.

@kirooshu 