### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Build gh-pages
 c866e1467a08548db08be1c8d28877eb21be88e4
+
+# Autoformat
+c59d4498f9849bca19925a45d6679402db7d888c

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Build gh-pages
+c866e1467a08548db08be1c8d28877eb21be88e4


### PR DESCRIPTION
[Add `.git-blame-ignore-revs` to ignore certain commits from blame.](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view)

We'll use this to ignore e.g. generating gh-pages build commit or autoformatting.