### PR TITLE
Drop special handling for blogIdentifier parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - **Breaking** Support Node.js versions `>=16`
+- **Breaking** blogIdentifier path parameters do not get special handling
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - **Breaking** Support Node.js versions `>=16`
-- **Breaking** blogIdentifier path parameters do not get special handling
+- `blogIdentifier` parameters do not get special treatment
 
 ### Added
 

--- a/integration/read-only.mjs
+++ b/integration/read-only.mjs
@@ -17,11 +17,13 @@ describe('consumer_key (api_key) only requests', () => {
     client.returnPromises();
   });
 
-  test('fetches blogInfo("staff")', async () => {
-    const resp = await client.blogInfo('staff');
-    assert.isOk(resp);
-    assert.equal(resp.blog.name, 'staff');
-    assert.equal(resp.blog.uuid, 't:0aY0xL2Fi1OFJg4YxpmegQ');
+  ['staff', 'staff.tumblr.com', 't:0aY0xL2Fi1OFJg4YxpmegQ'].forEach((blogIdentifier) => {
+    test(`fetches blogInfo(${JSON.stringify(blogIdentifier)})`, async () => {
+      const resp = await client.blogInfo(blogIdentifier);
+      assert.isOk(resp);
+      assert.equal(resp.blog.name, 'staff');
+      assert.equal(resp.blog.uuid, 't:0aY0xL2Fi1OFJg4YxpmegQ');
+    });
   });
 });
 

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -352,22 +352,6 @@ const API_METHODS = {
 };
 
 /**
- * Turns a blog name to a full blog URL
- *
- * @param  {string} blogUrl - blog name or URL
- *
- * @return {string} full blog URL
- *
- * @private
- */
-function forceFullBlogUrl(blogUrl) {
-  if (blogUrl.indexOf('.') < 0 || !blogUrl.startsWith('t:')) {
-    blogUrl += '.tumblr.com';
-  }
-  return blogUrl;
-}
-
-/**
  * Creates a named function with the desired signature
  *
  * @param  {string} name - function name
@@ -604,10 +588,7 @@ function addMethod(client, methodName, apiPath, paramNames, requestType) {
       apiPathSplit,
       function (apiPath, apiPathChunk) {
         // Parse arguments in the path
-        if (apiPathChunk === ':blogIdentifier') {
-          // Blog URLs are special
-          apiPathChunk = forceFullBlogUrl(args[pathParamIndex++]);
-        } else if (apiPathChunk[0] === ':') {
+        if (apiPathChunk[0] === ':') {
           apiPathChunk = args[pathParamIndex++];
         }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "mocha",
     "test:coverage": "nyc mocha",
     "test:integration": "mocha ./integration",
-    "lint": "eslint --report-unused-disable-directives lib test"
+    "lint": "eslint --report-unused-disable-directives --ext 'js' --ext 'mjs' lib test integration"
   },
   "engines": {
     "node": ">=16",


### PR DESCRIPTION
Drop special handling for `:blogIdentifier` path parameters.
Add integration test for 3 forms of blogIdentifier path parameters.

The API documentation is clear that three forms are allowed.
See https://www.tumblr.com/docs/en/api/v2#blog-identifiers.

- Blog name e.g. staff for https://staff.tumblr.com/
- Hostname e.g. staff.tumblr.com
- Universally unique identifier (UUID) e.g. t:0aY0xL2Fi1OFJg4YxpmegQ for staff

Special treatment of blogIdentifiers was buggy and broke the UUID form.
It was unnecessary, the API handles blog name or hostname properly
(`staff` is treated the same as `staff.tumblr.com`).

Closes #93 