### PR TITLE
Refactor as class and simplify options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,27 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Changed
-
-- **Breaking** Support Node.js versions `>=16`
-- `blogIdentifier` parameters do not get special treatment
-
 ### Added
 
 - Integration test suites using real API.
+
+### Changed
+
+- **Breaking** Support Node.js versions `>=16`.
+- **Breaking** `Client` constructor accepts single options argument.
+- **Breaking** Credentials should be provided directly as options, not nested under the
+  `credentials` property.
+- **Breaking** The (optional) `baseUrl` option should be of the form `https://example.com` with no
+  pathname, search, hash, etc. Bad `baseUrl` options will throw.
+
+### Fixed
+
+- `blogIdentifier` parameters will not have `.tumblr.com` automatically appended. Blog UUIDs can now
+  be used as `blogIdentifiers`.
+
+### Removed
+
+- **Breaking** The `request` option has been removed.
 
 ## [3.0.0] - 2020-07-28
 

--- a/integration/read-only.mjs
+++ b/integration/read-only.mjs
@@ -3,14 +3,31 @@ import { Client } from 'tumblr.js';
 import { assert } from 'chai';
 import { test } from 'mocha';
 
-if (!env.TUMBLR_OAUTH_CONSUMER_KEY) {
-  throw new Error('Must provide TUMBLR_OAUTH_CONSUMER_KEY environment variable');
-}
+describe.only('unauthorized requests', () => {
+  /** @type {Client} */
+  let client;
+  before(() => {
+    client = new Client();
+    client.returnPromises();
+  });
+
+  ['staff', 'staff.tumblr.com', 't:0aY0xL2Fi1OFJg4YxpmegQ'].forEach((blogIdentifier) => {
+    test(`fetches blogAvatar(${JSON.stringify(blogIdentifier)})`, async () => {
+      const { avatar_url } = await client.blogAvatar(blogIdentifier);
+      assert.isString(avatar_url);
+    });
+  });
+});
 
 describe('consumer_key (api_key) only requests', () => {
   /** @type {Client} */
   let client;
   before(() => {
+    if (!env.TUMBLR_OAUTH_CONSUMER_KEY) {
+      console.log('Provide TUMBLR_OAUTH_CONSUMER_KEY environment variable to run this block');
+      this.skip();
+    }
+
     client = new Client({
       consumer_key: env.TUMBLR_OAUTH_CONSUMER_KEY,
     });
@@ -27,13 +44,14 @@ describe('consumer_key (api_key) only requests', () => {
   });
 });
 
-const OAUTH1_ENV_VARS = [
-  'TUMBLR_OAUTH_CONSUMER_SECRET',
-  'TUMBLR_OAUTH_TOKEN',
-  'TUMBLR_OAUTH_CONSUMER_SECRET',
-];
-
 describe('oauth1 requests', () => {
+  const OAUTH1_ENV_VARS = [
+    'TUMBLR_OAUTH_CONSUMER_KEY',
+    'TUMBLR_OAUTH_CONSUMER_SECRET',
+    'TUMBLR_OAUTH_TOKEN',
+    'TUMBLR_OAUTH_CONSUMER_SECRET',
+  ];
+
   /** @type {Client} */
   let client;
   before(function () {

--- a/integration/read-only.mjs
+++ b/integration/read-only.mjs
@@ -22,7 +22,7 @@ describe('unauthorized requests', () => {
 describe('consumer_key (api_key) only requests', () => {
   /** @type {Client} */
   let client;
-  before(() => {
+  before(function () {
     if (!env.TUMBLR_OAUTH_CONSUMER_KEY) {
       console.log('Provide TUMBLR_OAUTH_CONSUMER_KEY environment variable to run this block');
       this.skip();

--- a/integration/read-only.mjs
+++ b/integration/read-only.mjs
@@ -3,7 +3,7 @@ import { Client } from 'tumblr.js';
 import { assert } from 'chai';
 import { test } from 'mocha';
 
-describe.only('unauthorized requests', () => {
+describe('unauthorized requests', () => {
   /** @type {Client} */
   let client;
   before(() => {

--- a/integration/write.mjs
+++ b/integration/write.mjs
@@ -3,19 +3,20 @@ import { Client } from 'tumblr.js';
 import { assert } from 'chai';
 import { test } from 'mocha';
 
-if (
-  !env.TUMBLR_OAUTH_CONSUMER_KEY ||
-  !env.TUMBLR_OAUTH_CONSUMER_SECRET ||
-  !env.TUMBLR_OAUTH_TOKEN ||
-  !env.TUMBLR_OAUTH_TOKEN_SECRET
-) {
-  throw new Error('Must provide all Oauth1 environment variables');
-}
-
 describe('oauth1 write requests', () => {
   /** @type {Client} */
   let client;
   before(function () {
+    if (
+      !env.TUMBLR_OAUTH_CONSUMER_KEY ||
+      !env.TUMBLR_OAUTH_CONSUMER_SECRET ||
+      !env.TUMBLR_OAUTH_TOKEN ||
+      !env.TUMBLR_OAUTH_TOKEN_SECRET
+    ) {
+      console.log('Must provide all Oauth1 environment variables');
+      this.skip();
+    }
+
     if (!env.CI) {
       console.warn(
         'This test suite uses the API to make changes. Modify the test suite to enabled it.',

--- a/lib/tumblr.d.ts
+++ b/lib/tumblr.d.ts
@@ -2,16 +2,22 @@ declare module 'tumblr.js' {
   type TumblrClientCallback = (err: any, resp: any, rawResp?: string) => void;
 
   interface Options {
-    consumer_key: string;
+    /** OAuth1 credential. Required for API key auth endpoints. */
+    consumer_key?: string;
+    /** OAuth1 credential. Required for OAuth endpoints. */
     consumer_secret?: string;
+    /** OAuth1 credential. Required for OAuth endpoints. */
     token?: string;
+    /** OAuth1 credential. Required for Oauth endpoints. */
     token_secret?: string;
+    /** (optional) The API url if different from the default. */
     baseUrl?: string;
+    /** (optional) Use promises instead of callbacks. */
     returnPromises?: boolean;
   }
 
   class TumblrClient {
-    constructor(options: Options);
+    constructor(options?: Options);
 
     userInfo(callback: TumblrClientCallback): void;
 
@@ -134,7 +140,7 @@ declare module 'tumblr.js' {
     ): Request;
   }
 
-  function createClient(options: Options): TumblrClient;
+  function createClient(options?: Options): TumblrClient;
 
   interface TextPostParams {
     title?: string;

--- a/lib/tumblr.d.ts
+++ b/lib/tumblr.d.ts
@@ -1,7 +1,18 @@
 declare module 'tumblr.js' {
   type TumblrClientCallback = (err: any, resp: any, rawResp?: string) => void;
 
-  interface TumblrClient {
+  interface Options {
+    consumer_key: string;
+    consumer_secret?: string;
+    token?: string;
+    token_secret?: string;
+    baseUrl?: string;
+    returnPromises?: boolean;
+  }
+
+  class TumblrClient {
+    constructor(options: Options);
+
     userInfo(callback: TumblrClientCallback): void;
 
     blogAvatar(
@@ -123,7 +134,7 @@ declare module 'tumblr.js' {
     ): Request;
   }
 
-  function createClient(options: any): TumblrClient;
+  function createClient(options: Options): TumblrClient;
 
   interface TextPostParams {
     title?: string;

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -753,7 +753,6 @@ class TumblrClient {
       }
     }
 
-    this.request = get(options, 'request', request);
     this.requestOptions = {
       followRedirect: false,
       headers: {
@@ -926,7 +925,7 @@ class TumblrClient {
       params = {};
     }
     return getRequest(
-      this.request.get,
+      request.get,
       this.credentials,
       this.baseUrl,
       apiPath,
@@ -951,7 +950,7 @@ class TumblrClient {
       params = {};
     }
     return postRequest(
-      this.request.post,
+      request.post,
       this.credentials,
       this.baseUrl,
       apiPath,

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -719,10 +719,10 @@ function wrapCreatePost(type, validate) {
 
 /**
  * @typedef Options
- * @property {string}  consumer_key      OAuth1 credential. Required.
- * @property {string}  [consumer_secret] OAuth1 credential. Required for some endpoints.
- * @property {string}  [token]           OAuth1 credential. Required for some endpoints.
- * @property {string}  [token_secret]    OAuth1 credential. Required for some endpoints.
+ * @property {string}  [consumer_key]    OAuth1 credential. Required for API key auth endpoints.
+ * @property {string}  [consumer_secret] OAuth1 credential. Required for OAuth endpoints.
+ * @property {string}  [token]           OAuth1 credential. Required for OAuth endpoints.
+ * @property {string}  [token_secret]    OAuth1 credential. Required for Oauth endpoints.
  * @property {string}  [baseUrl]         (optional) The API url if different from the default.
  * @property {boolean} [returnPromises]  (optional) Use promises instead of callbacks.
  */
@@ -731,13 +731,13 @@ class TumblrClient {
   /**
    * Creates a Tumblr API client using the given options
    *
-   * @param  {Options} options - client options
+   * @param  {Options} [options] - client options
    *
    * @constructor
    */
   constructor(options) {
     this.version = CLIENT_VERSION;
-    this.credentials = get(options, 'credentials', omit(options, 'baseUrl', 'request'));
+    this.credentials = omit(options, 'baseUrl', 'request', 'returnPromises');
     this.baseUrl = get(options, 'baseUrl', API_BASE_URL);
 
     // if someone is providing a custom baseUrl with a path, show a message
@@ -1012,7 +1012,7 @@ module.exports = {
   /**
    * Creates a Tumblr Client
    *
-   * @param  {Options} options - client options
+   * @param  {Options} [options] - client options
    *
    * @return {TumblrClient} {@link TumblrClient} instance
    *

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -717,30 +717,25 @@ function wrapCreatePost(type, validate) {
   };
 }
 
+/**
+ * @typedef Options
+ * @property {string}  consumer_key      OAuth1 credential. Required.
+ * @property {string}  [consumer_secret] OAuth1 credential. Required for some endpoints.
+ * @property {string}  [token]           OAuth1 credential. Required for some endpoints.
+ * @property {string}  [token_secret]    OAuth1 credential. Required for some endpoints.
+ * @property {string}  [baseUrl]         (optional) The API url if different from the default.
+ * @property {boolean} [returnPromises]  (optional) Use promises instead of callbacks.
+ */
+
 class TumblrClient {
   /**
    * Creates a Tumblr API client using the given options
    *
-   * @param  {Object} [options] - client options
-   * @param  {Object} [options.credentials] - OAuth credentials
-   * @param  {string} [options.baseUrl] - API base URL
-   * @param  {Object} [options.request] - library to use for making requests
+   * @param  {Options} options - client options
    *
    * @constructor
    */
   constructor(options) {
-    // Support for `TumblrClient(credentials, baseUrl, requestLibrary)`
-    if (arguments.length > 1) {
-      options = {
-        credentials: arguments[0],
-        baseUrl: arguments[1],
-        request: arguments[2],
-        returnPromises: false,
-      };
-    }
-
-    options = options || {};
-
     this.version = CLIENT_VERSION;
     this.credentials = get(options, 'credentials', omit(options, 'baseUrl', 'request'));
     this.baseUrl = get(options, 'baseUrl', API_BASE_URL);
@@ -1018,10 +1013,7 @@ module.exports = {
   /**
    * Creates a Tumblr Client
    *
-   * @param  {Object} [options] - client options
-   * @param  {Object} [options.credentials] - OAuth credentials
-   * @param  {string} [options.baseUrl] - API base URL
-   * @param  {Object} [options.request] - library to use for making requests
+   * @param  {Options} options - client options
    *
    * @return {TumblrClient} {@link TumblrClient} instance
    *
@@ -1029,19 +1021,6 @@ module.exports = {
    * @see {@link TumblrClient}
    */
   createClient: function (options) {
-    // Support for `TumblrClient(credentials, baseUrl, requestLibrary)`
-    if (arguments.length > 1) {
-      options = {
-        credentials: arguments[0],
-        baseUrl: arguments[1],
-        request: arguments[2],
-        returnPromises: false,
-      };
-    }
-
-    // Create the Tumblr Client
-    const client = new TumblrClient(options);
-
-    return client;
+    return new TumblrClient(options);
   },
 };

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -717,280 +717,282 @@ function wrapCreatePost(type, validate) {
   };
 }
 
-/**
- * Creates a Tumblr API client using the given options
- *
- * @param  {Object} [options] - client options
- * @param  {Object} [options.credentials] - OAuth credentials
- * @param  {string} [options.baseUrl] - API base URL
- * @param  {Object} [options.request] - library to use for making requests
- *
- * @constructor
- */
-function TumblrClient(options) {
-  // Support for `TumblrClient(credentials, baseUrl, requestLibrary)`
-  if (arguments.length > 1) {
-    options = {
-      credentials: arguments[0],
-      baseUrl: arguments[1],
-      request: arguments[2],
-      returnPromises: false,
+class TumblrClient {
+  /**
+   * Creates a Tumblr API client using the given options
+   *
+   * @param  {Object} [options] - client options
+   * @param  {Object} [options.credentials] - OAuth credentials
+   * @param  {string} [options.baseUrl] - API base URL
+   * @param  {Object} [options.request] - library to use for making requests
+   *
+   * @constructor
+   */
+  constructor(options) {
+    // Support for `TumblrClient(credentials, baseUrl, requestLibrary)`
+    if (arguments.length > 1) {
+      options = {
+        credentials: arguments[0],
+        baseUrl: arguments[1],
+        request: arguments[2],
+        returnPromises: false,
+      };
+    }
+
+    options = options || {};
+
+    this.version = CLIENT_VERSION;
+    this.credentials = get(options, 'credentials', omit(options, 'baseUrl', 'request'));
+    this.baseUrl = get(options, 'baseUrl', API_BASE_URL);
+
+    // if someone is providing a custom baseUrl with a path, show a message
+    // to help them debug if they run into errors.
+    if (this.baseUrl !== API_BASE_URL && this.baseUrl !== '') {
+      const baseUrl = new URL(this.baseUrl);
+      if (baseUrl.pathname !== '/') {
+        /* eslint-disable no-console */
+        console.warn('WARNING! Path detected in your custom baseUrl!');
+        console.warn('As of version 3.0.0, tumblr.js no longer includes a path in the baseUrl.');
+        console.warn('If you encounter errors, please try to omit the path.');
+        /* eslint-enable no-console */
+      }
+    }
+
+    this.request = get(options, 'request', request);
+    this.requestOptions = {
+      followRedirect: false,
+      headers: {
+        'User-Agent': 'tumblr.js/' + CLIENT_VERSION,
+      },
     };
-  }
 
-  options = options || {};
+    this.addGetMethods(API_METHODS.GET);
+    this.addPostMethods(API_METHODS.POST);
 
-  this.version = CLIENT_VERSION;
-  this.credentials = get(options, 'credentials', omit(options, 'baseUrl', 'request'));
-  this.baseUrl = get(options, 'baseUrl', API_BASE_URL);
+    /**
+     * Creates a text post on the given blog
+     *
+     * @see {@link https://www.tumblr.com/docs/api/v2#ptext-posts|API docs}
+     *
+     * @method createTextPost
+     *
+     * @param  {string} blogIdentifier - blog name or URL
+     * @param  {Object} params - parameters sent with the request
+     * @param  {string} [params.title] - post title text
+     * @param  {string} params.body - post body text
+     * @param  {TumblrClient~callback} [callback] - invoked when the request completes
+     *
+     * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
+     *
+     * @memberof TumblrClient
+     */
+    this.createTextPost = wrapCreatePost('text', ['body']);
 
-  // if someone is providing a custom baseUrl with a path, show a message
-  // to help them debug if they run into errors.
-  if (this.baseUrl !== API_BASE_URL && this.baseUrl !== '') {
-    const baseUrl = new URL(this.baseUrl);
-    if (baseUrl.pathname !== '/') {
-      /* eslint-disable no-console */
-      console.warn('WARNING! Path detected in your custom baseUrl!');
-      console.warn('As of version 3.0.0, tumblr.js no longer includes a path in the baseUrl.');
-      console.warn('If you encounter errors, please try to omit the path.');
-      /* eslint-enable no-console */
+    /**
+     * Creates a photo post on the given blog
+     *
+     * @see {@link https://www.tumblr.com/docs/api/v2#pphoto-posts|API docs}
+     *
+     * @method createPhotoPost
+     *
+     * @param  {string} blogIdentifier - blog name or URL
+     * @param  {Object} params - parameters sent with the request
+     * @param  {string} params.source - image source URL
+     * @param  {Stream|Array} params.data - an image or array of images
+     * @param  {string} params.data64 - base64-encoded image data
+     * @param  {string} [params.caption] - post caption text
+     * @param  {TumblrClient~callback} [callback] - invoked when the request completes
+     *
+     * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
+     *
+     * @memberof TumblrClient
+     */
+    this.createPhotoPost = wrapCreatePost('photo', ['data', 'data64', 'source']);
+
+    /**
+     * Creates a quote post on the given blog
+     *
+     * @see {@link https://www.tumblr.com/docs/api/v2#pquote-posts|API docs}
+     *
+     * @method createQuotePost
+     *
+     * @param  {string} blogIdentifier - blog name or URL
+     * @param  {Object} params - parameters sent with the request
+     * @param  {string} params.quote - quote text
+     * @param  {string} [params.source] - quote source
+     * @param  {TumblrClient~callback} [callback] - invoked when the request completes
+     *
+     * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
+     *
+     * @memberof TumblrClient
+     */
+    this.createQuotePost = wrapCreatePost('quote', ['quote']);
+
+    /**
+     * Creates a link post on the given blog
+     *
+     * @see {@link https://www.tumblr.com/docs/api/v2#plink-posts|API docs}
+     *
+     * @method createLinkPost
+     *
+     * @param  {string} blogIdentifier - blog name or URL
+     * @param  {Object} params - parameters sent with the request
+     * @param  {string} [params.title] - post title text
+     * @param  {string} params.url - the link URL
+     * @param  {string} [params.thumbnail] - the URL of an image to use as the thumbnail
+     * @param  {string} [params.excerpt] - an excerpt from the page the link points to
+     * @param  {string} [params.author] - the name of the author of the page the link points to
+     * @param  {string} [params.description] - post caption text
+     * @param  {TumblrClient~callback} [callback] - invoked when the request completes
+     *
+     * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
+     *
+     * @memberof TumblrClient
+     */
+    this.createLinkPost = wrapCreatePost('link', ['url']);
+
+    /**
+     * Creates a chat post on the given blog
+     *
+     * @see {@link https://www.tumblr.com/docs/api/v2#pchat-posts|API docs}
+     *
+     * @method createChatPost
+     *
+     * @param  {string} blogIdentifier - blog name or URL
+     * @param  {Object} params - parameters sent with the request
+     * @param  {string} [params.title] - post title text
+     * @param  {string} params.conversation - chat text
+     * @param  {TumblrClient~callback} [callback] - invoked when the request completes
+     *
+     * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
+     *
+     * @memberof TumblrClient
+     */
+    this.createChatPost = wrapCreatePost('chat', ['conversation']);
+
+    /**
+     * Creates an audio post on the given blog
+     *
+     * @see {@link https://www.tumblr.com/docs/api/v2#paudio-posts|API docs}
+     *
+     * @method createAudioPost
+     *
+     * @param  {string} blogIdentifier - blog name or URL
+     * @param  {Object} params - parameters sent with the request
+     * @param  {string} params.external_url - image source URL
+     * @param  {Stream} params.data - an audio file
+     * @param  {string} [params.caption] - post caption text
+     * @param  {TumblrClient~callback} [callback] - invoked when the request completes
+     *
+     * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
+     *
+     * @memberof TumblrClient
+     */
+    this.createAudioPost = wrapCreatePost('audio', ['data', 'data64', 'external_url']);
+
+    /**
+     * Creates a video post on the given blog
+     *
+     * @see {@link https://www.tumblr.com/docs/api/v2#pvideo-posts|API docs}
+     *
+     * @method createVideoPost
+     *
+     * @param  {string} blogIdentifier - blog name or URL
+     * @param  {Object} params - parameters sent with the request
+     * @param  {string} params.embed - embed code or a video URL
+     * @param  {Stream} params.data - a video file
+     * @param  {string} [params.caption] - post caption text
+     * @param  {TumblrClient~callback} [callback] - invoked when the request completes
+     *
+     * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
+     *
+     * @memberof TumblrClient
+     */
+    this.createVideoPost = wrapCreatePost('video', ['data', 'data64', 'embed']);
+
+    // Enable Promise mode
+    if (get(options, 'returnPromises', false)) {
+      this.returnPromises();
     }
   }
 
-  this.request = get(options, 'request', request);
-  this.requestOptions = {
-    followRedirect: false,
-    headers: {
-      'User-Agent': 'tumblr.js/' + CLIENT_VERSION,
-    },
-  };
-
-  this.addGetMethods(API_METHODS.GET);
-  this.addPostMethods(API_METHODS.POST);
-
   /**
-   * Creates a text post on the given blog
+   * Performs a GET request
    *
-   * @see {@link https://www.tumblr.com/docs/api/v2#ptext-posts|API docs}
-   *
-   * @method createTextPost
-   *
-   * @param  {string} blogIdentifier - blog name or URL
-   * @param  {Object} params - parameters sent with the request
-   * @param  {string} [params.title] - post title text
-   * @param  {string} params.body - post body text
-   * @param  {TumblrClient~callback} [callback] - invoked when the request completes
+   * @param  {string} apiPath - URL path for the request
+   * @param  {Object} params - query parameters
+   * @param  {TumblrClient~callback} [callback] - request callback
    *
    * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
-   *
-   * @memberof TumblrClient
    */
-  this.createTextPost = wrapCreatePost('text', ['body']);
+  getRequest(apiPath, params, callback) {
+    if (isFunction(params)) {
+      callback = params;
+      params = {};
+    }
+    return getRequest(
+      this.request.get,
+      this.credentials,
+      this.baseUrl,
+      apiPath,
+      this.requestOptions,
+      params,
+      callback,
+    );
+  }
 
   /**
-   * Creates a photo post on the given blog
+   * Performs a POST request
    *
-   * @see {@link https://www.tumblr.com/docs/api/v2#pphoto-posts|API docs}
-   *
-   * @method createPhotoPost
-   *
-   * @param  {string} blogIdentifier - blog name or URL
-   * @param  {Object} params - parameters sent with the request
-   * @param  {string} params.source - image source URL
-   * @param  {Stream|Array} params.data - an image or array of images
-   * @param  {string} params.data64 - base64-encoded image data
-   * @param  {string} [params.caption] - post caption text
-   * @param  {TumblrClient~callback} [callback] - invoked when the request completes
+   * @param  {string} apiPath - URL path for the request
+   * @param  {Object} params - form parameters
+   * @param  {TumblrClient~callback} [callback] - request callback
    *
    * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
-   *
-   * @memberof TumblrClient
    */
-  this.createPhotoPost = wrapCreatePost('photo', ['data', 'data64', 'source']);
+  postRequest(apiPath, params, callback) {
+    if (isFunction(params)) {
+      callback = params;
+      params = {};
+    }
+    return postRequest(
+      this.request.post,
+      this.credentials,
+      this.baseUrl,
+      apiPath,
+      this.requestOptions,
+      params,
+      callback,
+    );
+  }
 
   /**
-   * Creates a quote post on the given blog
-   *
-   * @see {@link https://www.tumblr.com/docs/api/v2#pquote-posts|API docs}
-   *
-   * @method createQuotePost
-   *
-   * @param  {string} blogIdentifier - blog name or URL
-   * @param  {Object} params - parameters sent with the request
-   * @param  {string} params.quote - quote text
-   * @param  {string} [params.source] - quote source
-   * @param  {TumblrClient~callback} [callback] - invoked when the request completes
-   *
-   * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
-   *
-   * @memberof TumblrClient
+   * Sets the client to return Promises instead of Request objects by patching the `getRequest` and
+   * `postRequest` methods on the client
    */
-  this.createQuotePost = wrapCreatePost('quote', ['quote']);
+  returnPromises() {
+    this.getRequest = promisifyRequest(this.getRequest);
+    this.postRequest = promisifyRequest(this.postRequest);
+  }
 
   /**
-   * Creates a link post on the given blog
+   * Adds GET methods to the client
    *
-   * @see {@link https://www.tumblr.com/docs/api/v2#plink-posts|API docs}
-   *
-   * @method createLinkPost
-   *
-   * @param  {string} blogIdentifier - blog name or URL
-   * @param  {Object} params - parameters sent with the request
-   * @param  {string} [params.title] - post title text
-   * @param  {string} params.url - the link URL
-   * @param  {string} [params.thumbnail] - the URL of an image to use as the thumbnail
-   * @param  {string} [params.excerpt] - an excerpt from the page the link points to
-   * @param  {string} [params.author] - the name of the author of the page the link points to
-   * @param  {string} [params.description] - post caption text
-   * @param  {TumblrClient~callback} [callback] - invoked when the request completes
-   *
-   * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
-   *
-   * @memberof TumblrClient
+   * @param  {Object} methods - mapping of method names to endpoints
    */
-  this.createLinkPost = wrapCreatePost('link', ['url']);
+  addGetMethods(methods) {
+    addMethods(this, methods, 'GET');
+  }
 
   /**
-   * Creates a chat post on the given blog
+   * Adds POST methods to the client
    *
-   * @see {@link https://www.tumblr.com/docs/api/v2#pchat-posts|API docs}
-   *
-   * @method createChatPost
-   *
-   * @param  {string} blogIdentifier - blog name or URL
-   * @param  {Object} params - parameters sent with the request
-   * @param  {string} [params.title] - post title text
-   * @param  {string} params.conversation - chat text
-   * @param  {TumblrClient~callback} [callback] - invoked when the request completes
-   *
-   * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
-   *
-   * @memberof TumblrClient
+   * @param  {Object} methods - mapping of method names to endpoints
    */
-  this.createChatPost = wrapCreatePost('chat', ['conversation']);
-
-  /**
-   * Creates an audio post on the given blog
-   *
-   * @see {@link https://www.tumblr.com/docs/api/v2#paudio-posts|API docs}
-   *
-   * @method createAudioPost
-   *
-   * @param  {string} blogIdentifier - blog name or URL
-   * @param  {Object} params - parameters sent with the request
-   * @param  {string} params.external_url - image source URL
-   * @param  {Stream} params.data - an audio file
-   * @param  {string} [params.caption] - post caption text
-   * @param  {TumblrClient~callback} [callback] - invoked when the request completes
-   *
-   * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
-   *
-   * @memberof TumblrClient
-   */
-  this.createAudioPost = wrapCreatePost('audio', ['data', 'data64', 'external_url']);
-
-  /**
-   * Creates a video post on the given blog
-   *
-   * @see {@link https://www.tumblr.com/docs/api/v2#pvideo-posts|API docs}
-   *
-   * @method createVideoPost
-   *
-   * @param  {string} blogIdentifier - blog name or URL
-   * @param  {Object} params - parameters sent with the request
-   * @param  {string} params.embed - embed code or a video URL
-   * @param  {Stream} params.data - a video file
-   * @param  {string} [params.caption] - post caption text
-   * @param  {TumblrClient~callback} [callback] - invoked when the request completes
-   *
-   * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
-   *
-   * @memberof TumblrClient
-   */
-  this.createVideoPost = wrapCreatePost('video', ['data', 'data64', 'embed']);
-
-  // Enable Promise mode
-  if (get(options, 'returnPromises', false)) {
-    this.returnPromises();
+  addPostMethods(methods) {
+    addMethods(this, methods, 'POST');
   }
 }
-
-/**
- * Performs a GET request
- *
- * @param  {string} apiPath - URL path for the request
- * @param  {Object} params - query parameters
- * @param  {TumblrClient~callback} [callback] - request callback
- *
- * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
- */
-TumblrClient.prototype.getRequest = function (apiPath, params, callback) {
-  if (isFunction(params)) {
-    callback = params;
-    params = {};
-  }
-  return getRequest(
-    this.request.get,
-    this.credentials,
-    this.baseUrl,
-    apiPath,
-    this.requestOptions,
-    params,
-    callback,
-  );
-};
-
-/**
- * Performs a POST request
- *
- * @param  {string} apiPath - URL path for the request
- * @param  {Object} params - form parameters
- * @param  {TumblrClient~callback} [callback] - request callback
- *
- * @return {Request|Promise} Request object, or Promise if {@link returnPromises} was used
- */
-TumblrClient.prototype.postRequest = function (apiPath, params, callback) {
-  if (isFunction(params)) {
-    callback = params;
-    params = {};
-  }
-  return postRequest(
-    this.request.post,
-    this.credentials,
-    this.baseUrl,
-    apiPath,
-    this.requestOptions,
-    params,
-    callback,
-  );
-};
-
-/**
- * Sets the client to return Promises instead of Request objects by patching the `getRequest` and
- * `postRequest` methods on the client
- */
-TumblrClient.prototype.returnPromises = function () {
-  this.getRequest = promisifyRequest(this.getRequest);
-  this.postRequest = promisifyRequest(this.postRequest);
-};
-
-/**
- * Adds GET methods to the client
- *
- * @param  {Object} methods - mapping of method names to endpoints
- */
-TumblrClient.prototype.addGetMethods = function (methods) {
-  addMethods(this, methods, 'GET');
-};
-
-/**
- * Adds POST methods to the client
- *
- * @param  {Object} methods - mapping of method names to endpoints
- */
-TumblrClient.prototype.addPostMethods = function (methods) {
-  addMethods(this, methods, 'POST');
-};
 
 /**
  * Handles the response from a client reuest

--- a/test/tumblr.test.js
+++ b/test/tumblr.test.js
@@ -41,32 +41,17 @@ describe('tumblr.js', function () {
     });
 
     it('passes credentials to the client', function () {
-      const credentials = DUMMY_CREDENTIALS;
-
-      // tumblr.createClient(credentials, baseUrl, requestLibrary)
-      let client = tumblr.createClient(credentials);
-      assert.equal(client.credentials.consumer_key, credentials.consumer_key);
-      assert.equal(client.credentials.consumer_secret, credentials.consumer_secret);
-      assert.equal(client.credentials.token, credentials.token);
-      assert.equal(client.credentials.token_secret, credentials.token_secret);
-
-      // tumblr.createClient(options)
-      client = tumblr.createClient({ credentials: credentials });
-      assert.equal(client.credentials.consumer_key, credentials.consumer_key);
-      assert.equal(client.credentials.consumer_secret, credentials.consumer_secret);
-      assert.equal(client.credentials.token, credentials.token);
-      assert.equal(client.credentials.token_secret, credentials.token_secret);
+      const client = tumblr.createClient(DUMMY_CREDENTIALS);
+      assert.equal(client.credentials.consumer_key, DUMMY_CREDENTIALS.consumer_key);
+      assert.equal(client.credentials.consumer_secret, DUMMY_CREDENTIALS.consumer_secret);
+      assert.equal(client.credentials.token, DUMMY_CREDENTIALS.token);
+      assert.equal(client.credentials.token_secret, DUMMY_CREDENTIALS.token_secret);
     });
 
     it('passes baseUrl to the client', function () {
       const baseUrl = 'https://t.umblr.com/v2';
 
-      // tumblr.createClient(credentials, baseUrl, requestLibrary)
-      let client = tumblr.createClient({}, baseUrl);
-      assert.equal(client.baseUrl, baseUrl);
-
-      // tumblr.createClient(options)
-      client = tumblr.createClient({ baseUrl: baseUrl });
+      const client = tumblr.createClient({ baseUrl: baseUrl });
       assert.equal(client.baseUrl, baseUrl);
     });
 
@@ -80,13 +65,11 @@ describe('tumblr.js', function () {
         },
       };
 
-      // TumblrClient(options)
       const client = tumblr.createClient({ request: requestLibrary });
       assert.equal(client.request, requestLibrary);
     });
 
     it('passes returnPromises to the client', function () {
-      // tumblr.createClient(options)
       const client = tumblr.createClient({ returnPromises: true });
       assert.notEqual(client.getRequest, tumblr.Client.prototype.getRequest);
       assert.notEqual(client.postRequest, tumblr.Client.prototype.postRequest);
@@ -104,39 +87,20 @@ describe('tumblr.js', function () {
       });
 
       it('uses the supplied credentials', function () {
-        let client;
-        const credentials = DUMMY_CREDENTIALS;
-
-        // TumblrClient(credentials, baseUrl, requestLibrary)
-        client = new TumblrClient(credentials);
-        assert.equal(client.credentials.consumer_key, credentials.consumer_key);
-        assert.equal(client.credentials.consumer_secret, credentials.consumer_secret);
-        assert.equal(client.credentials.token, credentials.token);
-        assert.equal(client.credentials.token_secret, credentials.token_secret);
-
-        // TumblrClient(options)
-        client = new TumblrClient({ credentials: credentials });
-        assert.equal(client.credentials.consumer_key, credentials.consumer_key);
-        assert.equal(client.credentials.consumer_secret, credentials.consumer_secret);
-        assert.equal(client.credentials.token, credentials.token);
-        assert.equal(client.credentials.token_secret, credentials.token_secret);
+        const client = new TumblrClient(DUMMY_CREDENTIALS);
+        assert.equal(client.credentials.consumer_key, DUMMY_CREDENTIALS.consumer_key);
+        assert.equal(client.credentials.consumer_secret, DUMMY_CREDENTIALS.consumer_secret);
+        assert.equal(client.credentials.token, DUMMY_CREDENTIALS.token);
+        assert.equal(client.credentials.token_secret, DUMMY_CREDENTIALS.token_secret);
       });
 
       it('uses the supplied baseUrl', function () {
-        let client;
         const baseUrl = DUMMY_API_URL;
-
-        // TumblrClient(credentials, baseUrl, requestLibrary)
-        client = tumblr.createClient({}, baseUrl);
-        assert.equal(client.baseUrl, baseUrl);
-
-        // TumblrClient(options)
-        client = tumblr.createClient({ baseUrl: baseUrl });
+        const client = tumblr.createClient({ baseUrl: baseUrl });
         assert.equal(client.baseUrl, baseUrl);
       });
 
       it('uses the supplied requestLibrary', function () {
-        let client;
         const requestLibrary = {
           get: function (options, callback) {
             return callback(options);
@@ -146,23 +110,12 @@ describe('tumblr.js', function () {
           },
         };
 
-        // TumblrClient(credentials, baseUrl, requestLibrary)
-        client = new TumblrClient({}, '', requestLibrary);
-        assert.equal(client.request, requestLibrary);
-
-        // TumblrClient(options)
-        client = new TumblrClient({ request: requestLibrary });
+        const client = new TumblrClient({ request: requestLibrary });
         assert.equal(client.request, requestLibrary);
       });
 
       it('uses the supplied returnPromises value', function () {
-        // tumblr.createClient(options)
-        let client = tumblr.createClient({ returnPromises: false });
-        assert.equal(client.getRequest, tumblr.Client.prototype.getRequest);
-        assert.equal(client.postRequest, tumblr.Client.prototype.postRequest);
-
-        // tumblr.createClient(options)
-        client = tumblr.createClient({ returnPromises: true });
+        const client = tumblr.createClient({ returnPromises: true });
         assert.notEqual(client.getRequest, tumblr.Client.prototype.getRequest);
         assert.notEqual(client.postRequest, tumblr.Client.prototype.postRequest);
       });

--- a/test/tumblr.test.js
+++ b/test/tumblr.test.js
@@ -55,20 +55,6 @@ describe('tumblr.js', function () {
       assert.equal(client.baseUrl, baseUrl);
     });
 
-    it('passes requestLibrary to the client', function () {
-      const requestLibrary = {
-        get: function (options, callback) {
-          return callback(options);
-        },
-        post: function (options, callback) {
-          return callback(options);
-        },
-      };
-
-      const client = tumblr.createClient({ request: requestLibrary });
-      assert.equal(client.request, requestLibrary);
-    });
-
     it('passes returnPromises to the client', function () {
       const client = tumblr.createClient({ returnPromises: true });
       assert.notEqual(client.getRequest, tumblr.Client.prototype.getRequest);
@@ -100,20 +86,6 @@ describe('tumblr.js', function () {
         assert.equal(client.baseUrl, baseUrl);
       });
 
-      it('uses the supplied requestLibrary', function () {
-        const requestLibrary = {
-          get: function (options, callback) {
-            return callback(options);
-          },
-          post: function (options, callback) {
-            return callback(options);
-          },
-        };
-
-        const client = new TumblrClient({ request: requestLibrary });
-        assert.equal(client.request, requestLibrary);
-      });
-
       it('uses the supplied returnPromises value', function () {
         const client = tumblr.createClient({ returnPromises: true });
         assert.notEqual(client.getRequest, tumblr.Client.prototype.getRequest);
@@ -124,11 +96,6 @@ describe('tumblr.js', function () {
         it('uses the default Tumblr API base URL', function () {
           const client = tumblr.createClient();
           assert.equal(client.baseUrl, 'https://api.tumblr.com');
-        });
-
-        it('uses default request library', function () {
-          const client = tumblr.createClient();
-          assert.equal(client.request, require('request'));
         });
 
         it('does not return Promises', function () {
@@ -285,7 +252,7 @@ describe('tumblr.js', function () {
                     it('returns a Request');
                   } else {
                     it('returns a Request', function () {
-                      assert.isTrue(returnValue instanceof client.request.Request);
+                      assert.isTrue(returnValue instanceof require('request').Request);
                     });
                   }
 

--- a/test/tumblr.test.js
+++ b/test/tumblr.test.js
@@ -9,6 +9,8 @@ const lowerCase = require('lodash/lowerCase');
 const assert = require('chai').assert;
 const nock = require('nock');
 
+nock.disableNetConnect();
+
 const DUMMY_CREDENTIALS = {
   consumer_key: 'Mario',
   consumer_secret: 'Luigi',
@@ -120,7 +122,7 @@ describe('tumblr.js', function () {
     let client;
     beforeEach(function () {
       client = new TumblrClient({
-        credentials: DUMMY_CREDENTIALS,
+        ...DUMMY_CREDENTIALS,
         baseUrl: DUMMY_API_URL,
         returnPromises: false,
       });


### PR DESCRIPTION
- Refactor as class
- Remove multiple argument constructor form
- Credentials should be provided in options.
- Remove `request` option
- Update tests to remove request option
- Update type declarations with Options
