### PR TITLE
Fix blogPosts method

### DIFF
--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -560,12 +560,7 @@ class TumblrClient {
    * @param  {TumblrClientCallback} [callback] **Deprecated** Omit the callback and use the promise form
    */
   blogPosts(blogIdentifier, paramsOrCallback, callback) {
-    let type = undefined;
-    if (paramsOrCallback && typeof paramsOrCallback !== 'function') {
-      type = paramsOrCallback.type;
-      delete paramsOrCallback.type;
-    }
-    return this.getRequest(`/v2/blog/${blogIdentifier}/posts/${type}`, paramsOrCallback, callback);
+    return this.getRequest(`/v2/blog/${blogIdentifier}/posts`, paramsOrCallback, callback);
   }
 
   /**


### PR DESCRIPTION
`blogPosts` could query `/…/undefined` which is an error. According to docs the post `type` is a URL parameter, but it works just fine as a query parameter.