### PR TITLE
Use JSON encoding unless we have file uploads

### DIFF
--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -269,33 +269,42 @@ class TumblrClient {
     }
 
     if (data) {
-      const form = new FormData();
+      // We use multipart/form-data if we have media to upload
+      if (data.has('data') || data.has('data64')) {
+        const form = new FormData();
 
-      const isLegacyPhotoPost = url.pathname.endsWith('/post') && data.get('type') === 'photo';
+        const isLegacyPhotoPost = url.pathname.endsWith('/post') && data.get('type') === 'photo';
 
-      for (const [key, value] of data.entries()) {
-        // Legacy photo post creation has a special case to accept `data`.
-        if (isLegacyPhotoPost && key === 'data') {
-          (Array.isArray(value) ? value : [value]).forEach((arrValue, index) => {
-            form.append(`${key}[${index}]`, arrValue);
-          });
-          continue;
+        for (const [key, value] of data.entries()) {
+          // Legacy photo post creation has a special case to accept `data`.
+          if (isLegacyPhotoPost && key === 'data') {
+            (Array.isArray(value) ? value : [value]).forEach((arrValue, index) => {
+              form.append(`${key}[${index}]`, arrValue);
+            });
+            continue;
+          }
+
+          // NPF endpoints use a special "json" field
+          if (key === 'json' && typeof value === 'string') {
+            form.append(key, value, { contentType: 'application/json' });
+            continue;
+          }
+
+          form.append(key, value);
         }
 
-        // NPF endpoints use a special "json" field
-        if (key === 'json' && typeof value === 'string') {
-          form.append(key, value, { contentType: 'application/json' });
-          continue;
+        for (const [key, value] of Object.entries(form.getHeaders())) {
+          request.setHeader(key, value);
         }
 
-        form.append(key, value);
+        form.pipe(request);
+      } else {
+        // Otherwise, we'll JSON encode the body
+        const requestBody = JSON.stringify(Object.fromEntries(data.entries()));
+        request.setHeader('Content-Type', 'application/json');
+        request.setHeader('Content-Length', requestBody.length);
+        request.write(requestBody);
       }
-
-      for (const [key, value] of Object.entries(form.getHeaders())) {
-        request.setHeader(key, value);
-      }
-
-      form.pipe(request);
     }
 
     let responseData = '';

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -502,10 +502,8 @@ class TumblrClient {
    */
   #transformNpfParams(params) {
     const transformed = {
-      json: JSON.stringify({
-        ...params,
-        ...(Array.isArray(params.tags) && { tags: params.tags.join(',') }),
-      }),
+      ...params,
+      ...(Array.isArray(params.tags) && { tags: params.tags.join(',') }),
     };
 
     return transformed;


### PR DESCRIPTION
The API uses `multipart/form-data` or `application/json` bodies to `POST`/`PUT` data sent to the API. It's necessary to use `multipart/form-data` when mixing media uploads and textual data, otherwise JSON is sufficient.

Use `JSON` except in cases that send `data` or `data64` fields used for media uploads.