### PR TITLE
Fix error when sending boolean values in form-data

### DIFF
--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -290,6 +290,13 @@ class TumblrClient {
             continue;
           }
 
+          // Some types of of values error when form-data appends them
+          // or when they're piped into the request buffer.
+          if (typeof value === 'boolean') {
+            form.append(key, JSON.stringify(value));
+            continue;
+          }
+
           form.append(key, value);
         }
 

--- a/test/tumblr.test.js
+++ b/test/tumblr.test.js
@@ -257,9 +257,35 @@ describe('tumblr.js', function () {
             .post('/', new RegExp(`^Content-Disposition: form-data; name="${dataField}"$`, 'm'))
             .reply(200, { meta: {}, response: {} });
 
-          assert.isOk(await client.postRequest('/', { [dataField]: ':D' }));
+          assert.isOk(
+            await client.postRequest('/', {
+              [dataField]: ':D',
+            }),
+          );
           scope.done();
         });
+      });
+
+      it('serializes different types of form-data fiels', async () => {
+        const client = new TumblrClient({
+          ...DUMMY_CREDENTIALS,
+          baseUrl: DUMMY_API_URL,
+        });
+        const scope = nock(client.baseUrl, {
+          reqheaders: { 'content-type': /^multipart\/form-data;/ },
+        })
+          .post('/')
+          .reply(200, { meta: {}, response: {} });
+
+        assert.isOk(
+          await client.postRequest('/', {
+            data: Buffer.from(''),
+
+            // Ensure common field types can be form-data serialized
+            booleanField: true,
+          }),
+        );
+        scope.done();
       });
 
       it('without body', async () => {

--- a/test/tumblr.test.js
+++ b/test/tumblr.test.js
@@ -257,11 +257,7 @@ describe('tumblr.js', function () {
             .post('/', new RegExp(`^Content-Disposition: form-data; name="${dataField}"$`, 'm'))
             .reply(200, { meta: {}, response: {} });
 
-          assert.isOk(
-            await client.postRequest('/', {
-              [dataField]: ':D',
-            }),
-          );
+          assert.isOk(await client.postRequest('/', { [dataField]: ':D' }));
           scope.done();
         });
       });


### PR DESCRIPTION
Fix an error thrown when sending boolean values via form-data.

On `main` the error can be replicated as follows:

```js
await require('tumblr.js').createClient(CREDENTIALS).blogPosts('staff', {npf:true,data:''})
```