### PR TITLE
fix README headings for `editPost` and `deletePost`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,13 @@ await client.createPost(blogName, {
 });
 ```
 
-#### Create a post with `editPost`
+#### Edit a post with `editPost`
 
 ```js
 await client.editPost(blogName, postId, options);
 ```
 
-#### Create a post with `deletePost`
+#### Delete a post with `deletePost`
 
 ```js
 await client.deletePost(blogName, postId);


### PR DESCRIPTION
I don't think `editPost` or `deletePost` create posts. Use the correct verbs in the README headings for these methods.