### PR TITLE
Fix Content-Length header calculation

### DIFF
--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -294,7 +294,7 @@ class Client {
         // Otherwise, we'll JSON encode the body
         const requestBody = JSON.stringify(Object.fromEntries(data.entries()));
         request.setHeader('Content-Type', 'application/json');
-        request.setHeader('Content-Length', requestBody.length);
+        request.setHeader('Content-Length', Buffer.byteLength(requestBody, 'utf-8'));
         request.write(requestBody);
       }
     }

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -294,8 +294,8 @@ class Client {
         // Otherwise, we'll JSON encode the body
         const requestBody = JSON.stringify(Object.fromEntries(data.entries()));
         request.setHeader('Content-Type', 'application/json');
-        request.setHeader('Content-Length', Buffer.byteLength(requestBody, 'utf-8'));
-        request.write(requestBody);
+        request.setHeader('Content-Length', Buffer.byteLength(requestBody, 'utf8'));
+        request.write(requestBody, 'utf8');
       }
     }
 

--- a/test/tumblr.test.mjs
+++ b/test/tumblr.test.mjs
@@ -288,6 +288,7 @@ describe('tumblr.js', function () {
 
     describe('post request expected headers', () => {
       it('with body', async () => {
+        const body = '{"foo":"bar"}';
         const client = new TumblrClient({
           ...DUMMY_CREDENTIALS,
           baseUrl: DUMMY_API_URL,
@@ -297,6 +298,7 @@ describe('tumblr.js', function () {
             accept: 'application/json',
             'user-agent': `tumblr.js/${tumblr.Client.version}`,
             'content-type': 'application/json',
+            'content-length': Buffer.byteLength(body, 'utf-8').toString(),
             authorization: (value) => {
               return [
                 value.startsWith('OAuth '),
@@ -311,10 +313,26 @@ describe('tumblr.js', function () {
             },
           },
         })
-          .post('/', '{"foo":"bar"}')
+          .post('/', body)
           .reply(200, { meta: {}, response: {} });
 
         assert.isOk(await client.postRequest('/', { foo: 'bar' }));
+        scope.done();
+      });
+
+      it('with unicode in body', async () => {
+        const body = '{"powerup":"🍄"}';
+        const client = new TumblrClient({
+          ...DUMMY_CREDENTIALS,
+          baseUrl: DUMMY_API_URL,
+        });
+        const scope = nock(client.baseUrl, {
+          reqheaders: { 'content-length': Buffer.byteLength(body, 'utf-8').toString() },
+        })
+          .post('/', body)
+          .reply(200, { meta: {}, response: {} });
+
+        assert.isOk(await client.postRequest('/', { powerup: '🍄' }));
         scope.done();
       });
 


### PR DESCRIPTION
I've been investigating `400` errors when editing the tags on a post using `editLegacyPost`, and narrowed it down to when the tags contained non-ASCII characters. For example:

`POST https://api.tumblr.com/v2/blog/tagreplacertest/post/edit`
```json
{ "id": "723659158787915776", "tags": "tag1,tag☃︎2" }
```
```json
{
  "meta": { "status": 400, "msg": "Bad Request" },
  "response": [],
  "errors": [
    { "title": "Bad Request", "code": 5009, "detail": "the request payload contains invalid JSON" }
  ]
}
```

I tried making the same request using Postman, and it succeeded. So I compared the `tumblr.js` request to the Postman request and noticed the `Content-Length` header was different. [`String.length`](https://github.com/tumblr/tumblr.js/blob/main/lib/tumblr.js#L297) gives us the number of bytes in UTF-16, but the default encoding of our request body is UTF-8. I'm pretty sure this is also causing https://github.com/tumblr/tumblr.js/issues/242.

This PR calculates the `Content-Length` header in UTF-8 using `Buffer.byteLength` and adds a corresponding test. 

