### PR TITLE
Add types export condition to package exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,8 @@ provided.
 
 ## [1.0.0] - 2016-05-09
 
-[unreleased]: https://github.com/tumblr/tumblr.js/compare/v5.0.0...HEAD
+[unreleased]: https://github.com/tumblr/tumblr.js/compare/v5.0.1...HEAD
+[5.0.1]: https://github.com/tumblr/tumblr.js/releases/tag/v5.0.1
 [5.0.0]: https://github.com/tumblr/tumblr.js/releases/tag/v5.0.0
 [4.0.1]: https://github.com/tumblr/tumblr.js/releases/tag/v4.0.1
 [4.0.0]: https://github.com/tumblr/tumblr.js/releases/tag/v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.1] - 2025-05-02
+
+### Fixed
+
+- Ensure type declarations can be discovered in certain build setups.
+
 ## [5.0.0] - 2024-02-22
 
 ### Changed

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -19,7 +19,7 @@ class Client {
    * Package version
    * @readonly
    */
-  static version = '5.0.0';
+  static version = '5.0.1';
 
   /**
    * @typedef {import('./types').TumblrClientCallback} TumblrClientCallback

--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
   "name": "tumblr.js",
-  "version": "5.0.0",
+  "version": "5.0.1-alpha.1",
   "description": "Official JavaScript client for the Tumblr API",
   "main": "./lib/tumblr",
   "type": "commonjs",
   "exports": {
-    ".": {
-      "types": "./types/tumblr.d.ts",
-      "default": "./lib/tumblr.js"
-    }
+    "types": "./types/tumblr.d.ts",
+    "default": "./lib/tumblr.js"
   },
   "types": "./types/tumblr.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "tumblr.js",
-  "version": "5.0.1-alpha.1",
+  "version": "5.0.0",
   "description": "Official JavaScript client for the Tumblr API",
   "main": "./lib/tumblr",
   "type": "commonjs",
   "exports": {
-    "types": "./types/tumblr.d.ts",
-    "default": "./lib/tumblr.js"
+    ".": {
+      "types": "./types/tumblr.d.ts",
+      "default": "./lib/tumblr.js"
+    }
   },
   "types": "./types/tumblr.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "./lib/tumblr",
   "type": "commonjs",
   "exports": {
-    ".": "./lib/tumblr.js"
+    ".": {
+      "types": "./types/tumblr.d.ts",
+      "default": "./lib/tumblr.js"
+    }
   },
   "types": "./types/tumblr.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tumblr.js",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Official JavaScript client for the Tumblr API",
   "main": "./lib/tumblr",
   "type": "commonjs",


### PR DESCRIPTION
Add `types` condition to the exports field.

It appears that in some situations, in particular with modules, TypeScript was unable to locate the types when using the exports field in from package.json.

This seems to fix the issue by adding `types` and `default` conditions to the export.

Fixes #523