### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   static-checks:
     name: Static checks


### PR DESCRIPTION
Potential fix for [https://github.com/tumblr/tumblr.js/security/code-scanning/5](https://github.com/tumblr/tumblr.js/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yaml` so all jobs inherit least-privilege access by default. For this workflow, `contents: read` is the best minimal setting and should preserve current behavior (checkout/read operations) without granting unnecessary write scopes.

Best single change:
- Edit `.github/workflows/ci.yaml` near the top (after `on:` triggers and before `jobs:`).
- Insert:
  - `permissions:`
  - `  contents: read`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
