### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   static-checks:
     name: Static checks


### PR DESCRIPTION
Potential fix for [https://github.com/tumblr/tumblr.js/security/code-scanning/3](https://github.com/tumblr/tumblr.js/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yaml` so all jobs inherit least-privilege token scopes.  
Best single fix without changing behavior: set:

```yaml
permissions:
  contents: read
```

This supports `actions/checkout` and typical read-only CI tasks while preventing unintended write scopes. Place it at workflow root (e.g., after `on:` block and before `jobs:`), so you don’t need to duplicate per job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
