### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate_yaml.yaml
+++ b/.github/workflows/validate_yaml.yaml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   validate-yaml:
     name: Validate YAML


### PR DESCRIPTION
Potential fix for [https://github.com/tumblr/tumblr.js/security/code-scanning/2](https://github.com/tumblr/tumblr.js/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/validate_yaml.yaml` at the workflow root so it applies to all jobs (including `validate-yaml`) unless overridden.  
For this workflow, the least-privilege baseline is:

- `contents: read`

This is sufficient for `actions/checkout` and linting repository files, and it does not change intended functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
