### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   static-checks:
     name: Static checks


### PR DESCRIPTION
Potential fix for [https://github.com/tumblr/tumblr.js/security/code-scanning/4](https://github.com/tumblr/tumblr.js/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root so it applies to all jobs unless overridden.  
For this workflow, the minimal safe baseline is:

```yaml
permissions:
  contents: read
```

This preserves current behavior for checkout/build/test jobs while enforcing least privilege for `GITHUB_TOKEN`.

**Where to change:** `.github/workflows/ci.yaml`, near the top-level keys (`name`, `on`, `jobs`).  
**What to add:** a top-level `permissions` section between `on` and `jobs` (or anywhere at root level with correct YAML indentation).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
