### PR TITLE
Accept stream.Readable for media uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ const blogSubmissions = await client.blogSubmissions(blogName, options);
 await client.createPost(blogName, options);
 ```
 
-To upload media with a created post, provide a `ReadStream` as the block media:
+To upload media with a created post, provide a `Readable` stream as the block media:
 
 ```js
 await client.createPost(blogName, {

--- a/lib/tumblr.js
+++ b/lib/tumblr.js
@@ -8,9 +8,9 @@
 const FormData = require('form-data');
 const http = require('node:http');
 const https = require('node:https');
+const { Readable } = require('node:stream');
 const { URL } = require('node:url');
 const oauth = require('oauth');
-const { ReadStream } = require('node:fs');
 
 const API_BASE_URL = 'https://api.tumblr.com'; // deliberately no trailing slash
 
@@ -521,11 +521,11 @@ class Client {
    * @param  {import('./types').NpfReblogParams | import('./types').NpfPostParams } params
    */
   #transformNpfParams({ tags, content, ...params }) {
-    /** @type {Map<string, ReadStream>} */
+    /** @type {Map<string, Readable>} */
     const mediaStreams = new Map();
 
     const transformedContent = content.map((block, index) => {
-      if (block.media && block.media instanceof ReadStream) {
+      if (block.media && block.media instanceof Readable) {
         mediaStreams.set(String(index), block.media);
         return {
           ...block,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-import { type ReadStream } from 'node:fs';
+import { type Readable } from 'node:stream';
 import { type IncomingMessage } from 'node:http';
 
 export type PostType = 'text' | 'quote' | 'link' | 'answer' | 'video' | 'audio' | 'photo' | 'chat';
@@ -87,27 +87,27 @@ export interface MediaObject {
 export interface AudioBlock {
   type: 'audio';
   /**
-   * NPF MediaObject or Node.js fs.ReadStream object
+   * NPF MediaObject or Node.js stream.Readable object
    *
-   * Provide a fs.ReadStream object to upload media or an object satisfying the MediaObject interface to use existing media.
+   * Provide a stream.Readable object to upload media or an object satisfying the MediaObject interface to use existing media.
    *
    * @see [Media objects documentation.](https://www.tumblr.com/docs/npf#media-objects)
-   * @see [`fs.ReadStream` documentation.](https://nodejs.org/docs/latest-v20.x/api/fs.html#class-fsreadstream)
+   * @see [`stream.Readable` documentation.](https://nodejs.org/docs/latest-v20.x/api/stream.html#class-streamreadable)
    */
-  media: ReadStream | MediaObject;
+  media: Readable | MediaObject;
   [prop: string]: any;
 }
 export interface ImageBlock {
   type: 'image';
   /**
-   * NPF MediaObject or Node.js fs.ReadStream object
+   * NPF MediaObject or Node.js stream.Readable object
    *
-   * Provide a fs.ReadStream object to upload media or an object satisfying the MediaObject interface to use existing media.
+   * Provide a stream.Readable object to upload media or an object satisfying the MediaObject interface to use existing media.
    *
    * @see [Media objects documentation.](https://www.tumblr.com/docs/npf#media-objects)
-   * @see [`fs.ReadStream` documentation.](https://nodejs.org/docs/latest-v20.x/api/fs.html#class-fsreadstream)
+   * @see [`stream.Readable` documentation.](https://nodejs.org/docs/latest-v20.x/api/stream.html#class-streamreadable)
    */
-  media: ReadStream | MediaObject;
+  media: Readable | MediaObject;
   [prop: string]: any;
 }
 export interface LinkBlock {
@@ -125,14 +125,14 @@ export interface TextBlock {
 export interface VideoBlock {
   type: 'video';
   /**
-   * NPF MediaObject or Node.js fs.ReadStream object
+   * NPF MediaObject or Node.js stream.Readable object
    *
-   * Provide a fs.ReadStream object to upload media or an object satisfying the MediaObject interface to use existing media.
+   * Provide a stream.Readable object to upload media or an object satisfying the MediaObject interface to use existing media.
    *
    * @see [Media objects documentation.](https://www.tumblr.com/docs/npf#media-objects)
-   * @see [`fs.ReadStream` documentation.](https://nodejs.org/docs/latest-v20.x/api/fs.html#class-fsreadstream)
+   * @see [`stream.Readable` documentation.](https://nodejs.org/docs/latest-v20.x/api/stream.html#class-streamreadable)
    */
-  media: ReadStream | MediaObject;
+  media: Readable | MediaObject;
   [prop: string]: any;
 }
 

--- a/test/tumblr.test.mjs
+++ b/test/tumblr.test.mjs
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { Readable } from 'node:stream';
 import { assert } from 'chai';
 import * as tumblr from '../lib/tumblr.js';
 import nock from 'nock';
@@ -177,6 +178,32 @@ describe('tumblr.js', function () {
           assert.isFunction(client[methodName]);
         });
       });
+    });
+
+    it('createPost accepts stream.Readable media uploads', async () => {
+      const client = new TumblrClient({
+        ...DUMMY_CREDENTIALS,
+        baseUrl: DUMMY_API_URL,
+      });
+      const stream = Readable.from(['hello from a generic readable']);
+      const scope = nock(client.baseUrl, {
+        reqheaders: { 'content-type': /^multipart\/form-data;/ },
+      })
+        .post('/v2/blog/example.tumblr.com/posts', (body) => {
+          const payload = Buffer.isBuffer(body) ? body.toString('utf8') : String(body);
+          return (
+            payload.includes('name="json"') &&
+            payload.includes('"identifier":"0"') &&
+            payload.includes('name="0"') &&
+            payload.includes('hello from a generic readable')
+          );
+        })
+        .reply(200, { meta: {}, response: {} });
+
+      await client.createPost('example.tumblr.com', {
+        content: [{ type: 'image', media: stream, alt_text: 'example' }],
+      });
+      scope.done();
     });
 
     /**


### PR DESCRIPTION
I'm writing a bot and want to be able to upload in-memory images without having to write to temporary files, this change allows me to use `Readable.from(bytes)`.